### PR TITLE
RightSideBar 추가

### DIFF
--- a/client/src/components/common/RightSideBar/RightSideBar.tsx
+++ b/client/src/components/common/RightSideBar/RightSideBar.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  background-color: orange;
+`;
+
+interface RightSideBarProps {
+  Header: JSX.Element;
+  Body: JSX.Element;
+}
+
+const RightSideBar: React.FC<RightSideBarProps> = ({ Header, Body }: RightSideBarProps) => {
+  return (
+    <Container>
+      {Header}
+      {Body}
+    </Container>
+  );
+};
+
+export default RightSideBar;

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,2 +1,4 @@
 export { default as Header } from './Header/Header';
 export { default as WarningIcon } from './WarningIcon/WarningIcon';
+export { default as ThreadItem } from './ThreadItem/ThreadItem';
+export { default as RightSideBar } from './RightSideBar/RightSideBar';


### PR DESCRIPTION
RightSideBar 추가

추후 라우팅 연결
일단 상욱님이랑 나눠서 각자 작업.
RightSideBar에 props 넘기는 식으로 설계.