### PR TITLE
쓰레드 생성시 subThread 정보 업데이트 관련 코드 작성 / 리펙토링 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,11 +22,13 @@ const App = () => {
           <Route path="/login" component={LoginPage} />
           <Route path="/verify" component={EmailVerifyPage} />
           <Route path="/signup" component={SignupPage} />
-          <Route path="/client/1" exact component={WorkSpacePage} />
-          <Route path="/client/1/:channelId" exact component={WorkSpacePage} />
-          <Route path="/client/1/:channelId/:rightSideType" exact component={WorkSpacePage} />
           <Route
-            path="/client/1/:channelId/:rightSideType/:threadId"
+            path={[
+              '/client/1',
+              '/client/1/:channelId',
+              '/client/1/:channelId/:rightSideType',
+              '/client/1/:channelId/:rightSideType/:threadId',
+            ]}
             exact
             component={WorkSpacePage}
           />

--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { getThreadRequest } from '@/store/modules/thread';
 import styled from 'styled-components';

--- a/client/src/components/common/ThreadItem/ThreadPopup/ThreadPopup.tsx
+++ b/client/src/components/common/ThreadItem/ThreadPopup/ThreadPopup.tsx
@@ -58,15 +58,18 @@ const ThreadPopup: React.FC<ThreadPopupProps> = ({ thread }: ThreadPopupProps) =
       <MoreActionButton type="button" onClick={openMenuModal}>
         MoreActions
         {menuModalVisible && (
-          <Modal onClick={closeMenuModal}>
-            <MenuModal width="auto" visible={menuModalVisible} setVisible={setMenuModalVisible}>
-              <ModalListItem onClick={openEditModal}>Unfollow message</ModalListItem>
-              <ModalListItem>Copy link</ModalListItem>
-              <ModalListItem>Pin to this conversation</ModalListItem>
-              <ModalListItem>Edit message</ModalListItem>
-              <ModalListItem>Delete message</ModalListItem>
-            </MenuModal>
-          </Modal>
+          <MenuModal
+            top="1rem"
+            right="1rem"
+            visible={menuModalVisible}
+            setVisible={setMenuModalVisible}
+          >
+            <ModalListItem onClick={openEditModal}>Unfollow message</ModalListItem>
+            <ModalListItem>Copy link</ModalListItem>
+            <ModalListItem>Pin to this conversation</ModalListItem>
+            <ModalListItem>Edit message</ModalListItem>
+            <ModalListItem>Delete message</ModalListItem>
+          </MenuModal>
         )}
       </MoreActionButton>
     </Container>

--- a/server/src/models/thread.ts
+++ b/server/src/models/thread.ts
@@ -18,7 +18,7 @@ export const threadModel = {
     WHERE parent_id=? AND thread.is_deleted=0;`;
     return pool.execute(sql, [threadId]);
   },
-  getParentThread(threadId: number): any {
+  getThread(threadId: number): any {
     const sql = `SELECT thread.id AS id, user_id AS userId, channel_id AS channelId, content, url, is_edited AS isEdited, is_pinned AS isPinned, 
     thread.is_deleted AS isDeleted, parent_id AS parentId, emoji, thread.created_at AS createdAt, sub_count AS subCount, sub_thread_user_id_1 AS subThreadUserId1, sub_thread_user_id_2 AS subThreadUserId2, sub_thread_user_id_3 AS subThreadUserId3, 
     email, display_name AS displayName, phone_number AS phoneNumber, image
@@ -35,6 +35,14 @@ export const threadModel = {
   ): any {
     const sql = `INSERT INTO thread (user_id, channel_id, content, parent_id, url) VALUES (?,?,?,?,?)`;
     return pool.execute(sql, [userId, channelId, content, parentId, url]);
+  },
+  updateSubCountOfThread(parentId: number): any {
+    const sql = `UPDATE thread SET sub_count=sub_count+1 WHERE id=?;`;
+    return pool.execute(sql, [parentId]);
+  },
+  updateSubThreadUserIdOfThread(updateIndex: number, userId: number, parentId: number): any {
+    const sql = `UPDATE thread SET sub_thread_user_id_${updateIndex}=? WHERE id=?;`;
+    return pool.execute(sql, [userId, parentId]);
   },
   updateThread(content: string, threadId: number): any {
     const sql = `UPDATE thread SET content=? WHERE id=?;`;

--- a/server/src/routes/api/threads/[threadId]/threadId.controller.ts
+++ b/server/src/routes/api/threads/[threadId]/threadId.controller.ts
@@ -17,7 +17,7 @@ export const getSubThread = async (
     return;
   }
   try {
-    const [parentThread] = await threadModel.getParentThread(Number(threadId));
+    const [parentThread] = await threadModel.getThread(Number(threadId));
     const [subThreadList] = await threadModel.getSubThreadList(Number(threadId));
     res.json({ parentThread, subThreadList });
   } catch (err) {

--- a/server/src/routes/api/threads/threads.controller.ts
+++ b/server/src/routes/api/threads/threads.controller.ts
@@ -29,11 +29,12 @@ export const createThread = async (
       - SELECT sub_thread_user_id_1, sub_thread_user_id_2, sub_thread_user_id_3 FROM thread 
       */
       await threadModel.updateSubCountOfThread(parentId);
-
-      const [
-        { subThreadUserId1, subThreadUserId2, subThreadUserId3 },
-      ] = await threadModel.getThread(Number(parentId));
-      const subThreadUserIdList: number[] = [subThreadUserId1, subThreadUserId2, subThreadUserId3];
+      const [[parentThread]] = await threadModel.getThread(Number(parentId));
+      const subThreadUserIdList: number[] = [
+        parentThread.subThreadUserId1,
+        parentThread.subThreadUserId2,
+        parentThread.subThreadUserId3,
+      ];
 
       if (!subThreadUserIdList.find((subThreadUserId) => subThreadUserId === userId)) {
         const updateIndex = subThreadUserIdList.findIndex(


### PR DESCRIPTION
1. 쓰레드 생성시 subThread 정보 업데이트 관련 코드 작성 
- 이슈 #63 에 있는것과 같이 쿼리 4방으로 로직이 동작한다.
- 쓰레드 생성 및 subCount업데이트는 묶어서 1방에도 가능한데 subthreadUserId를 추가해주는 로직은..
- sub_Thread_user_id_1/2/3 필드를 업데이트 해주기 위한 로직은 아래와 같다.
  1) 해당 쓰레드 정보를 가져오는 쿼리를 날려 받은 다음,
  2) userId가 sub_Thread_user_id 필드1,2,3에 이미 들어가있는지 확인하고
  3) 없는경우, null자리가 있는지 확인하고 null자리가 있다면 userId를 추가.

2. 리펙토링 
불필요한 코드 삭제, wrong_params 상태코드 변경