### PR TITLE
채널 로직 수정, dm 생성을 카톡에서 사람을 추가하는 방법으로 구현

### DIFF
--- a/client/src/components/ChannelListBox/ChannelList/ChannelItem/ChannelItem.tsx
+++ b/client/src/components/ChannelListBox/ChannelList/ChannelItem/ChannelItem.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
-import { loadChannelRequest } from '@/store/modules/channel.slice';
 import { useJoinChannelListState, useChannelState } from '@/hooks';
 import { flex } from '@/styles/mixin';
 import { LockIcon, PoundIcon } from '@/components';
@@ -44,14 +42,14 @@ interface ChannelItemProps {
 }
 
 const ChannelItem = ({ idx }: ChannelItemProps) => {
-  const dispatch = useDispatch();
   const { id, name, isPublic } = useJoinChannelListState(idx);
   const { current } = useChannelState();
 
   const picked = id === current?.id;
 
   const onClick = () => {
-    dispatch(loadChannelRequest(id));
+    // 현재 picked 된거 바꿔주는 작업 필요합, 채널 접었다 폇다 하는거 어디갓지?
+    // 마지막 채널 갱신을 담당하는 사가는 삭제함, 그 작업은 채널 불러오면서 처리하기로 함
   };
 
   return (

--- a/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
@@ -149,8 +149,8 @@ const ChannelListBox = ({
       )}
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader first={channelType !== CHANNEL_TYPE.CHANNEL} />}
-          body={<AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first />}
+          header={<AddUsersModalHeader isDM={channelType !== CHANNEL_TYPE.CHANNEL} />}
+          body={<AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} isDM />}
           visible={addUsersModalVisible}
           setVisible={setAddUsersModalVisible}
         />

--- a/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
@@ -149,7 +149,7 @@ const ChannelListBox = ({
       )}
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader />}
+          header={<AddUsersModalHeader first={channelType !== CHANNEL_TYPE.CHANNEL} />}
           body={<AddUsersModalBody setAddUsersModalVisible={setAddChannelsModalVisible} first />}
           visible={addUsersModalVisible}
           setVisible={setAddUsersModalVisible}

--- a/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
@@ -150,7 +150,7 @@ const ChannelListBox = ({
       {addUsersModalVisible && (
         <DimModal
           header={<AddUsersModalHeader first={channelType !== CHANNEL_TYPE.CHANNEL} />}
-          body={<AddUsersModalBody setAddUsersModalVisible={setAddChannelsModalVisible} first />}
+          body={<AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first />}
           visible={addUsersModalVisible}
           setVisible={setAddUsersModalVisible}
         />

--- a/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
@@ -3,6 +3,10 @@ import styled, { css } from 'styled-components';
 import { flex } from '@/styles/mixin';
 import { CHANNEL_TYPE } from '@/utils/constants';
 import { DimModal, MenuModal, ArrowDownIcon, PlusIcon, DotIcon } from '@/components';
+import {
+  AddUsersModalHeader,
+  AddUsersModalBody,
+} from '@/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal';
 import { CreateChannelModalHeader, CreateChannelModalBody } from './CreateChannelModal';
 
 const Container = styled.div`
@@ -101,6 +105,7 @@ const ChannelListBox = ({
   const [addChannelsModalVisible, setAddChannelsModalVisible] = useState(false);
   const [sectionOptionsModalVisible, setSectionOptionsModalVisible] = useState(false);
   const [createChannelModalVisible, setCreateChannelModalVisible] = useState(false);
+  const [addUsersModalVisible, setAddUsersModalVisible] = useState(false);
   const [secret, setSecret] = useState(false);
 
   const toggleChannelList = () => {
@@ -120,6 +125,11 @@ const ChannelListBox = ({
   const clickCreateChannelModal = () => {
     setCreateChannelModalVisible(true);
   };
+
+  const clickAddUsersModal = () => {
+    setAddUsersModalVisible((state) => !state);
+  };
+
   return (
     <>
       {createChannelModalVisible && (
@@ -137,7 +147,15 @@ const ChannelListBox = ({
           setVisible={setCreateChannelModalVisible}
         />
       )}
-      <Container onClick={toggleChannelList}>
+      {addUsersModalVisible && (
+        <DimModal
+          header={<AddUsersModalHeader />}
+          body={<AddUsersModalBody setAddUsersModalVisible={setAddChannelsModalVisible} first />}
+          visible={addUsersModalVisible}
+          setVisible={setAddUsersModalVisible}
+        />
+      )}
+      <Container>
         {addChannelsModalVisible && (
           <MenuModal
             top="1.5rem"
@@ -145,7 +163,13 @@ const ChannelListBox = ({
             visible={addChannelsModalVisible}
             setVisible={setAddChannelsModalVisible}
           >
-            <ModalListItem onClick={clickCreateChannelModal}>
+            <ModalListItem
+              onClick={() =>
+                channelType === CHANNEL_TYPE.CHANNEL
+                  ? clickCreateChannelModal()
+                  : clickAddUsersModal()
+              }
+            >
               {channelType === CHANNEL_TYPE.CHANNEL ? '채널 추가' : '대화 상대 추가'}
             </ModalListItem>
             <ModalListItem>{channelType === CHANNEL_TYPE.CHANNEL && '채널 검색'}</ModalListItem>

--- a/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/no-unescaped-entities */
 /* eslint-disable @typescript-eslint/ban-types */
-import React, { ReactElement, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { flex } from '@/styles/mixin';
 import styled from 'styled-components';
-import { useAuthState, useUserState, useChannelState, useOnClickOutside } from '@/hooks';
-import { createChannelRequest, joinChannelRequset } from '@/store/modules/channel.slice';
+import { useAuthState, useChannelState, useUserState } from '@/hooks';
+import { createChannelRequest } from '@/store/modules/channel.slice';
 import { useDispatch } from 'react-redux';
 
 interface Props {
@@ -168,7 +168,6 @@ const CreateChannelModalBody: React.FC<CreateChannelModalBodyProps> = ({
   const { userId } = useAuthState();
   const { userInfo } = useUserState();
   const { current } = useChannelState();
-
   const dispatch = useDispatch();
 
   const changeName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -192,12 +191,9 @@ const CreateChannelModalBody: React.FC<CreateChannelModalBodyProps> = ({
         isPublic,
         name,
         description,
-        displayName: userInfo?.displayName,
+        users: [userInfo],
       }),
     );
-    if (userInfo && current) {
-      dispatch(joinChannelRequset({ users: [userInfo], channelId: current.id }));
-    }
     setCreateChannelModalVisible((state) => !state);
   };
 

--- a/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
@@ -3,8 +3,8 @@
 import React, { ReactElement, useRef, useState } from 'react';
 import { flex } from '@/styles/mixin';
 import styled from 'styled-components';
-import { createChannelRequest } from '@/store/modules/channel.slice';
-import { useAuthState, useUserState, useOnClickOutside } from '@/hooks';
+import { useAuthState, useUserState, useChannelState, useOnClickOutside } from '@/hooks';
+import { createChannelRequest, joinChannelRequset } from '@/store/modules/channel.slice';
 import { useDispatch } from 'react-redux';
 
 interface Props {
@@ -167,6 +167,7 @@ const CreateChannelModalBody: React.FC<CreateChannelModalBodyProps> = ({
   const [description, setDescription] = useState('');
   const { userId } = useAuthState();
   const { userInfo } = useUserState();
+  const { current } = useChannelState();
 
   const dispatch = useDispatch();
 
@@ -194,6 +195,9 @@ const CreateChannelModalBody: React.FC<CreateChannelModalBodyProps> = ({
         displayName: userInfo?.displayName,
       }),
     );
+    if (userInfo && current) {
+      dispatch(joinChannelRequset({ users: [userInfo], channelId: current.id }));
+    }
     setCreateChannelModalVisible((state) => !state);
   };
 

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
@@ -81,7 +81,7 @@ const SubmitButton = styled.button`
 
 interface AddUsersModalBodyProps {
   setAddUsersModalVisible: (a: any) => any;
-  first: boolean;
+  isDM: boolean;
 }
 
 interface RightSideParams {
@@ -90,7 +90,7 @@ interface RightSideParams {
 
 const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
   setAddUsersModalVisible,
-  first,
+  isDM,
 }: AddUsersModalBodyProps) => {
   const dispatch = useDispatch();
   const [text, setText] = useState('');
@@ -102,7 +102,7 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
 
   useEffect(() => {
     const debounce = setTimeout(() => {
-      dispatch(matchUsersRequest({ first, pickUsers, displayName: text, channelId: +channelId }));
+      dispatch(matchUsersRequest({ isDM, pickUsers, displayName: text, channelId: +channelId }));
       setVisible(true);
     }, 250);
 
@@ -126,7 +126,7 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
   };
 
   const clickSubmitButton = () => {
-    if (!first) {
+    if (!isDM) {
       dispatch(joinChannelRequset({ users: pickUsers, channelId: +channelId }));
     } else if (userInfo) {
       const name = makeDMRoomName(pickUsers, userInfo.displayName);

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
@@ -8,6 +8,7 @@ import { joinChannelRequset, createChannelRequest } from '@/store/modules/channe
 import { User } from '@/types';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
+import { makeDMRoomName } from '@/utils/utils';
 
 interface Props {
   visible: boolean;
@@ -127,10 +128,9 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
   const clickSubmitButton = () => {
     if (!first) {
       dispatch(joinChannelRequset({ users: pickUsers, channelId: +channelId }));
-    } else {
-      const name = pickUsers.reduce((acc, cur) => {
-        return `${acc}, ${cur.displayName}`;
-      }, `${userInfo?.displayName}`);
+    } else if (userInfo) {
+      const name = makeDMRoomName(pickUsers, userInfo.displayName);
+
       dispatch(
         createChannelRequest({
           ownerId: userInfo?.id,

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { flex } from '@/styles/mixin';
-import { getUsersRequest, matchUsersRequest } from '@/store/modules/user.slice';
+import { matchUsersRequest } from '@/store/modules/user.slice';
 import { useChannelState, useUserState } from '@/hooks';
 import { joinChannelRequset, createChannelRequest } from '@/store/modules/channel.slice';
 import { User } from '@/types';
@@ -98,11 +98,10 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
   const [pickUsers, setPickUsers] = useState<User[]>([]);
   const { channelId }: RightSideParams = useParams();
   const { userInfo } = useUserState();
-  const { current } = useChannelState();
 
   useEffect(() => {
     const debounce = setTimeout(() => {
-      dispatch(matchUsersRequest({ pickUsers, displayName: text, channelId: +channelId }));
+      dispatch(matchUsersRequest({ first, pickUsers, displayName: text, channelId: +channelId }));
       setVisible(true);
     }, 250);
 
@@ -130,8 +129,8 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
       dispatch(joinChannelRequset({ users: pickUsers, channelId: +channelId }));
     } else {
       const name = pickUsers.reduce((acc, cur) => {
-        return `${acc}, ${cur.email}`;
-      }, '');
+        return `${acc}, ${cur.displayName}`;
+      }, `${userInfo?.displayName}`);
       dispatch(
         createChannelRequest({
           ownerId: userInfo?.id,
@@ -140,11 +139,9 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
           name,
           description: '',
           displayName: '',
+          users: [userInfo, ...pickUsers],
         }),
       );
-      if (userInfo && current) {
-        dispatch(joinChannelRequset({ users: pickUsers, channelId: current.id }));
-      }
     }
     setAddUsersModalVisible((state) => !state);
   };

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/addUsersModalBody.tsx
@@ -79,7 +79,7 @@ const SubmitButton = styled.button`
 `;
 
 interface AddUsersModalBodyProps {
-  setAddUsersModalVisible: (fn: (state: boolean) => boolean) => void;
+  setAddUsersModalVisible: (a: any) => any;
   first: boolean;
 }
 
@@ -143,7 +143,7 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
         }),
       );
     }
-    setAddUsersModalVisible((state) => !state);
+    setAddUsersModalVisible(false);
   };
 
   return (

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalHeader/addUsersModalHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalHeader/addUsersModalHeader.tsx
@@ -15,15 +15,22 @@ const HeaderTitle = styled.div`
 const ChannelName = styled.div`
   font-size: ${(props) => props.theme.size.s};
 `;
-const AddUserModalHeader: React.FC = () => {
+
+interface AddUsersModalHeaderProps {
+  first: boolean;
+}
+
+const AddUserModalHeader: React.FC<AddUsersModalHeaderProps> = ({
+  first,
+}: AddUsersModalHeaderProps) => {
   const { current } = useChannelState();
 
   return (
     <Header>
       <HeaderTitle>Add People</HeaderTitle>
       <ChannelName>
-        {current?.isPublic}
-        {current?.name}
+        {!first && current?.isPublic}
+        {!first && current?.name}
       </ChannelName>
     </Header>
   );

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalHeader/addUsersModalHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalHeader/addUsersModalHeader.tsx
@@ -17,11 +17,11 @@ const ChannelName = styled.div`
 `;
 
 interface AddUsersModalHeaderProps {
-  first: boolean;
+  isDM: boolean;
 }
 
 const AddUserModalHeader: React.FC<AddUsersModalHeaderProps> = ({
-  first,
+  isDM,
 }: AddUsersModalHeaderProps) => {
   const { current } = useChannelState();
 
@@ -29,8 +29,8 @@ const AddUserModalHeader: React.FC<AddUsersModalHeaderProps> = ({
     <Header>
       <HeaderTitle>Add People</HeaderTitle>
       <ChannelName>
-        {!first && current?.isPublic}
-        {!first && current?.name}
+        {!isDM && current?.isPublic}
+        {!isDM && current?.name}
       </ChannelName>
     </Header>
   );

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/ShowUsersModal/ShowUsersModalBody/ShowUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/ShowUsersModal/ShowUsersModalBody/ShowUsersModalBody.tsx
@@ -70,7 +70,7 @@ const ShowUsersModalBody: React.FC<ShowUsersModalBody> = ({
     <>
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader />}
+          header={<AddUsersModalHeader first={false} />}
           body={
             <AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first={false} />
           }

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/ShowUsersModal/ShowUsersModalBody/ShowUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/ShowUsersModal/ShowUsersModalBody/ShowUsersModalBody.tsx
@@ -70,9 +70,9 @@ const ShowUsersModalBody: React.FC<ShowUsersModalBody> = ({
     <>
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader first={false} />}
+          header={<AddUsersModalHeader isDM={false} />}
           body={
-            <AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first={false} />
+            <AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} isDM={false} />
           }
           visible={addUsersModalVisible}
           setVisible={clickAddUsersModal}

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { CHANNEL_TYPE } from '@/utils/constants';
 import { JoinedUser } from '@/types';
 import { Link, useParams } from 'react-router-dom';
-import { loadChannelRequest, modifyLastChannelRequest } from '@/store/modules/channel.slice';
+import { loadChannelRequest } from '@/store/modules/channel.slice';
 import { DimModal, LockIcon, PoundIcon, WarningIcon, AddUserIcon } from '@/components';
 import theme from '@/styles/theme';
 import { flex, hoverActive } from '@/styles/mixin';
@@ -103,10 +103,7 @@ const ThreadListHeader = () => {
   const { channelId }: RightSideParams = useParams();
 
   useEffect(() => {
-    dispatch(loadChannelRequest(channelId));
-    if (userInfo) {
-      dispatch(modifyLastChannelRequest({ lastChannelId: +channelId, userId: userInfo.id }));
-    }
+    dispatch(loadChannelRequest({ channelId: +channelId, userId: userInfo?.id }));
   }, [channelId]);
 
   const clickShowUsersModal = () => {
@@ -125,7 +122,7 @@ const ThreadListHeader = () => {
     <>
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader />}
+          header={<AddUsersModalHeader first={false} />}
           body={
             <AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first={false} />
           }
@@ -167,16 +164,18 @@ const ThreadListHeader = () => {
         </LeftBox>
         <RightBox>
           {current?.channelType === CHANNEL_TYPE.CHANNEL && (
-            <UserImgBox onClick={clickShowUsersModal}>
-              {users.slice(0, 3).map((icon: JoinedUser, idx: number) => (
-                <UserImg zIndex={users.length - idx} key={icon.userId} src={icon.image} />
-              ))}
-              <UserCount>{users?.length}</UserCount>
-            </UserImgBox>
+            <>
+              <UserImgBox onClick={clickShowUsersModal}>
+                {users.slice(0, 3).map((icon: JoinedUser, idx: number) => (
+                  <UserImg zIndex={users.length - idx} key={icon.userId} src={icon.image} />
+                ))}
+                <UserCount>{users?.length}</UserCount>
+              </UserImgBox>
+              <AddUserBox onClick={clickAddUsersModal}>
+                <AddUserIcon size="1.4rem" />
+              </AddUserBox>
+            </>
           )}
-          <AddUserBox onClick={clickAddUsersModal}>
-            <AddUserIcon size="1.4rem" />
-          </AddUserBox>
           <Link to={`/client/1/${channelId}/detail`}>
             <InfoIconBox>
               <WarningIcon size="1.1rem" color={theme.color.black5} />

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -118,8 +118,6 @@ const ThreadListHeader = () => {
     setAddTopicModalVisible((state) => !state);
   };
 
-  console.log(addUsersModalVisible);
-
   return (
     <>
       {addUsersModalVisible && (

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -118,14 +118,14 @@ const ThreadListHeader = () => {
     setAddTopicModalVisible((state) => !state);
   };
 
+  console.log(addUsersModalVisible);
+
   return (
     <>
       {addUsersModalVisible && (
         <DimModal
           header={<AddUsersModalHeader first={false} />}
-          body={
-            <AddUsersModalBody setAddUsersModalVisible={setAddUsersModalVisible} first={false} />
-          }
+          body={<AddUsersModalBody setAddUsersModalVisible={clickAddUsersModal} first={false} />}
           visible={addUsersModalVisible}
           setVisible={clickAddUsersModal}
         />

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -103,8 +103,10 @@ const ThreadListHeader = () => {
   const { channelId }: RightSideParams = useParams();
 
   useEffect(() => {
-    dispatch(loadChannelRequest({ channelId: +channelId, userId: userInfo?.id }));
-  }, [channelId]);
+    if (userInfo) {
+      dispatch(loadChannelRequest({ channelId: +channelId, userId: userInfo.id }));
+    }
+  }, [channelId, userInfo]);
 
   const clickShowUsersModal = () => {
     setShowUsersModalVisible((state) => !state);

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -124,8 +124,8 @@ const ThreadListHeader = () => {
     <>
       {addUsersModalVisible && (
         <DimModal
-          header={<AddUsersModalHeader first={false} />}
-          body={<AddUsersModalBody setAddUsersModalVisible={clickAddUsersModal} first={false} />}
+          header={<AddUsersModalHeader isDM={false} />}
+          body={<AddUsersModalBody setAddUsersModalVisible={clickAddUsersModal} isDM={false} />}
           visible={addUsersModalVisible}
           setVisible={clickAddUsersModal}
         />

--- a/client/src/services/channel.service.ts
+++ b/client/src/services/channel.service.ts
@@ -11,8 +11,15 @@ export const channelService: Service = {
   getChannel({ channelId }: { channelId: number }) {
     return API.get(`/api/channels/${channelId}`);
   },
-  createChannel({ ownerId, name, channelType, isPublic, description }: ChannelInfo) {
-    return API.post('/api/channels', { ownerId, name, channelType, isPublic, description });
+  createChannel({ ownerId, name, channelType, isPublic, description, memberCount }: ChannelInfo) {
+    return API.post('/api/channels', {
+      ownerId,
+      name,
+      channelType,
+      isPublic,
+      description,
+      memberCount,
+    });
   },
   joinChannel({ users, channelId }: { users: User[]; channelId: number }) {
     return API.post(`/api/channels/${channelId}/invite`, { users });

--- a/client/src/services/user.service.ts
+++ b/client/src/services/user.service.ts
@@ -13,7 +13,15 @@ export const userService: Service = {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
   },
-  matchUsers({ displayName, channelId }: { displayName: string; channelId: number }) {
-    return API.post('/api/users/match', { displayName, channelId });
+  matchUsers({
+    displayName,
+    channelId,
+    first,
+  }: {
+    displayName: string;
+    channelId: number;
+    first: boolean;
+  }) {
+    return API.post('/api/users/match', { displayName, channelId, first });
   },
 };

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -53,7 +53,7 @@ const channelSlice = createSlice({
       // todo 에러처리
     },
     loadChannelRequest(state, action) {
-      state.channelId = action.payload;
+      state.channelId = action.payload.channelId;
     },
     loadChannelSuccess(state, action) {
       const [temp] = action.payload.channel;

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -71,14 +71,13 @@ const channelSlice = createSlice({
       state.channelList.push(action.payload.channel);
       state.myChannelList.push(action.payload.channel);
       state.current = action.payload.channel;
-      state.users = action.payload.joinedUser;
+      state.users = action.payload.joinedListUser;
     },
     createChannelFailure(state, action) {
       // todo 에러처리
     },
     joinChannelRequset(state, action: PayloadAction<joinChannelRequsetPayload>) {},
     joinChannelSuccess(state, action: PayloadAction<{ users: JoinedUser[] }>) {
-      console.log(action);
       state.users = action.payload.users;
     },
     joinChannelFailure(state, action) {

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -66,16 +66,12 @@ const channelSlice = createSlice({
     modifyTopicRequest(state, action) {},
     modifyTopicSuccess(state, action: PayloadAction<{ channelId: number }>) {},
     modifyTopicFailure(state, action) {},
-    modifyLastChannelRequest(state, action: PayloadAction<modifyLastChannelRequestPayload>) {},
-    modifyLastChannelSuccess() {},
-    modifyLastChannelFailure(state, action) {},
     createChannelRequest(state, action) {},
     createChannelSuccess(state, action) {
-      console.log(action);
       state.channelList.push(action.payload.channel);
       state.myChannelList.push(action.payload.channel);
       state.current = action.payload.channel;
-      state.users = [action.payload.JoinedUser];
+      state.users = action.payload.joinedUser;
     },
     createChannelFailure(state, action) {
       // todo 에러처리
@@ -112,9 +108,6 @@ export const {
   modifyTopicRequest,
   modifyTopicSuccess,
   modifyTopicFailure,
-  modifyLastChannelRequest,
-  modifyLastChannelSuccess,
-  modifyLastChannelFailure,
   createChannelRequest,
   createChannelSuccess,
   createChannelFailure,

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -71,6 +71,7 @@ const channelSlice = createSlice({
     modifyLastChannelFailure(state, action) {},
     createChannelRequest(state, action) {},
     createChannelSuccess(state, action) {
+      console.log(action);
       state.channelList.push(action.payload.channel);
       state.myChannelList.push(action.payload.channel);
       state.current = action.payload.channel;

--- a/client/src/store/modules/user.slice.ts
+++ b/client/src/store/modules/user.slice.ts
@@ -6,7 +6,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface UserState {
   userInfo: User | null;
-  usersInfo: User[] | null;
   edit: {
     loading: boolean;
     success: boolean;
@@ -17,7 +16,6 @@ export interface UserState {
 
 const userState: UserState = {
   userInfo: null,
-  usersInfo: null,
   edit: {
     loading: false,
     success: false,
@@ -75,11 +73,6 @@ const userSlice = createSlice({
       state.edit.success = false;
       state.edit.err = payload.err;
     },
-    getUsersRequest() {},
-    getUsersSuccess(state, { payload }: PayloadAction<{ usersInfo: User[] }>) {
-      state.usersInfo = payload.usersInfo;
-    },
-    getUsersFailure() {},
     matchUsersRequest(state, action) {},
     matchUsersSuccess(state, action) {
       state.matchUsersInfo = action.payload.matchUsersInfo;
@@ -96,9 +89,6 @@ export const {
   editUserRequest,
   editUserSuccess,
   editUserFailure,
-  getUsersRequest,
-  getUsersSuccess,
-  getUsersFailure,
   matchUsersRequest,
   matchUsersSuccess,
   matchUsersFailure,

--- a/client/src/store/sagas/channelSaga.ts
+++ b/client/src/store/sagas/channelSaga.ts
@@ -87,7 +87,7 @@ function* createChannel(action: any) {
       image: users[0].image,
     };
 
-    yield put(createChannelSuccess({ channel, joinedUser: [joinedUser] }));
+    yield put(createChannelSuccess({ channel, joinedListUser: [joinedUser] }));
     yield call(channelService.joinChannel, { users, channelId: result.data.channel.insertId });
   } catch (err) {
     yield put(createChannelFailure(err));

--- a/client/src/store/sagas/channelSaga.ts
+++ b/client/src/store/sagas/channelSaga.ts
@@ -59,7 +59,7 @@ function* loadChannel(action: any) {
 
 function* createChannel(action: any) {
   try {
-    const { ownerId, channelType, isPublic, name, description, displayName } = action.payload;
+    const { ownerId, channelType, isPublic, name, description } = action.payload;
     const result = yield call(channelService.createChannel, {
       ownerId,
       channelType,
@@ -79,6 +79,7 @@ function* createChannel(action: any) {
       memberCount: 1,
     };
 
+<<<<<<< HEAD
     const joinedUser: JoinedUser = {
       displayName,
       userId: ownerId,
@@ -87,6 +88,10 @@ function* createChannel(action: any) {
     };
     yield call(channelService.joinChannel, { userId: ownerId, channelId: channel.id });
     yield put(createChannelSuccess({ channel, joinedUser }));
+=======
+    yield call(channelService.joinChannel, { userId: ownerId, channelId: channel.id });
+    yield put(createChannelSuccess({ channel }));
+>>>>>>> cfc6f3e... [feat] 채널인지 dm인지에 따라서 처음에 생성해주는 것을 다르게 구현(미완성)
   } catch (err) {
     yield put(createChannelFailure(err));
   }

--- a/client/src/types/channelInfo.ts
+++ b/client/src/types/channelInfo.ts
@@ -4,4 +4,5 @@ export interface ChannelInfo {
   channelType: number;
   isPublic: number;
   description: string;
+  memberCount: number;
 }

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import config from '@/config';
-import { AuthToken, JoinedUser, Channel } from '@/types';
+import { AuthToken, JoinedUser, Channel, User } from '@/types';
 import { TOKEN_TYPE } from '@/utils/constants';
 
 import crypto from 'crypto';
@@ -59,4 +59,11 @@ export const isExistedChannel = ({
   myChannelList: Channel[];
 }): boolean => {
   return myChannelList.some((channel: Channel) => channel.id === channelId);
+};
+
+export const makeDMRoomName = (pickUsers: User[], startName: string) => {
+  const name = pickUsers.reduce((acc, cur) => {
+    return `${acc}, ${cur.displayName}`;
+  }, startName);
+  return name;
 };

--- a/server/src/models/channels.model.ts
+++ b/server/src/models/channels.model.ts
@@ -7,6 +7,7 @@ interface createInfo {
   channelType: number;
   isPublic: number;
   description: string;
+  memberCount: number;
 }
 
 interface TopicInfo {
@@ -47,13 +48,29 @@ export const channelModel = {
     `;
     return pool.execute(sql, [channelId]);
   },
-  createChannel({ ownerId, name, channelType, isPublic, description }: createInfo): any {
-    const sql = `INSERT INTO channel (owner_id, name, channel_type, is_public, description) VALUES (?, ?, ?, ?, ?)`;
-    return pool.execute(sql, [ownerId, name, channelType, isPublic, description]);
+  createChannel({
+    ownerId,
+    name,
+    channelType,
+    isPublic,
+    description,
+    memberCount,
+  }: createInfo): any {
+    const sql = `INSERT INTO channel (owner_id, name, channel_type, is_public, description, member_count) VALUES (?, ?, ?, ?, ?, ?)`;
+    return pool.execute(sql, [ownerId, name, channelType, isPublic, description, memberCount]);
   },
-  joinChannel(joinUsers: Array<Array<number>>): any {
-    const sql = `INSERT INTO user_channel (user_id, channel_id) VALUES ?`;
-    return pool.query(sql, [joinUsers]);
+  joinChannel({
+    joinUsers,
+    joinedNumber,
+    channelId,
+  }: {
+    joinUsers: Array<Array<number>>;
+    joinedNumber: number;
+    channelId: number;
+  }): any {
+    const sql = `INSERT INTO user_channel (user_id, channel_id) VALUES ?;
+    UPDATE channel SET member_count = ? WHERE id = ?`;
+    return pool.query(sql, [joinUsers, joinUsers.length + joinedNumber, channelId]);
   },
   modifyTopic({ channelId, topic }: TopicInfo) {
     const sql = 'UPDATE channel SET topic = ? WHERE id = ?';

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -11,6 +11,7 @@ interface EditUserParams {
 interface MatchUsers {
   displayName: string;
   channelId: number;
+  first: boolean;
 }
 
 export const userModel = {
@@ -47,13 +48,20 @@ export const userModel = {
     const sql = `UPDATE user SET display_name=?, phone_number=? WHERE id=?;`;
     return pool.execute(sql, [displayName, phoneNumber, id]);
   },
-  matchUsers({ displayName, channelId }: MatchUsers): any {
-    const sql = `SELECT DISTINCT id, pw, email, display_name as displayName, phone_number as phoneNumber, image
+  matchUsers({ displayName, channelId, first }: MatchUsers): any {
+    const sql1 = `SELECT DISTINCT id, pw, email, display_name as displayName, phone_number as phoneNumber, image
     FROM user
     WHERE display_name LIKE '${displayName}%' AND id NOT IN (
       SELECT user_id FROM user_channel
       WHERE channel_id = ?
     )`;
-    return pool.execute(sql, [channelId]);
+    const sql2 = `SELECT DISTINCT id, pw, email, display_name as displayName, phone_number as phoneNumber, image
+    FROM user
+    WHERE display_name LIKE '${displayName}%'`;
+    if (!first) {
+      return pool.execute(sql1, [channelId]);
+    }
+
+    return pool.query(sql2);
   },
 };

--- a/server/src/routes/api/channels/[channelId]/channelId.controller.ts
+++ b/server/src/routes/api/channels/[channelId]/channelId.controller.ts
@@ -33,7 +33,12 @@ export const inviteChannel = async (req: Request, res: Response, next: NextFunct
       acc.push([cur.id, +channelId]);
       return acc;
     }, []);
-    await channelModel.joinChannel(joinUsers);
+    const [joinedUsers] = await channelModel.getChannelUser({ channelId: +channelId });
+    await channelModel.joinChannel({
+      joinUsers,
+      joinedNumber: joinedUsers.length,
+      channelId: +channelId,
+    });
     res.status(200).end();
     return;
   }

--- a/server/src/routes/api/channels/channels.controller.ts
+++ b/server/src/routes/api/channels/channels.controller.ts
@@ -13,14 +13,15 @@ export const getChannels = async (req: Request, res: Response, next: NextFunctio
  * POST /api/channels
  */
 export const createChannel = async (req: Request, res: Response, next: NextFunction) => {
-  const { ownerId, name, channelType, isPublic, description } = req.body;
-  if (verifyRequestData([ownerId, name, channelType, isPublic])) {
+  const { ownerId, name, channelType, isPublic, description, memberCount } = req.body;
+  if (verifyRequestData([ownerId, name, channelType, isPublic, memberCount])) {
     const [channel] = await channelModel.createChannel({
       ownerId,
       name,
       channelType,
       isPublic,
       description,
+      memberCount,
     });
     res.status(200).json({ channel });
     return;

--- a/server/src/routes/api/users/users.controller.ts
+++ b/server/src/routes/api/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { userModel } from '@/models';
+import { channelModel, userModel } from '@/models';
 import { verifyRequestData } from '@/utils/utils';
 /**
  * GET /api/users
@@ -19,9 +19,9 @@ export const matchUsers = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const { displayName, channelId } = req.body;
+    const { displayName, channelId, first } = req.body;
     if (verifyRequestData([displayName, channelId])) {
-      const [matchUsersInfo] = await userModel.matchUsers({ displayName, channelId });
+      const [matchUsersInfo] = await userModel.matchUsers({ displayName, channelId, first });
       res.status(200).json({ matchUsersInfo });
       return;
     }


### PR DESCRIPTION
# 오늘 한 일
### 1. 채널 로직 수정
#### dm방 생성과 채널방 생성
- dm을 생성하는 경우, 현재 내가 선택한 사람을 모두 배열로 받아서 dm방을 생성하도록 구현(선택한 유저들을 모두 생성한 dm방에 가입시킨다.)
- 채널을 생성하는 경우, 현재 로그인한 유저만 길이 1의 배열로 넘겨서 채널을 생성하도록 구현(나만 생성한 채널에 가입시킨다.)
#### 유저 추가
- 현재 등록한 유저와 이미 등록한 유저를 합친 값으로 현재 채널의 가입된 유저의 수를 변경한다.
#### 쓰레드 리스트 헤더 수정
- dm방은 한 번 생성이 되면 사람을 추가할 수 없다.

### 2. dm생성
- 유저를 추가하는 모달이 바로 뜨고 거기서 선택한 유저를 데리고 방을 생성할 수 있다.