### PR TITLE
소켓 이벤트 컨벤션, 타입, 상수 정의, 채팅 구현

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "cross-env MODE=dev webpack-dev-server --open --mode development",
+    "dev": "cross-env MODE=dev webpack-dev-server --open --mode development --progress",
     "watch": "webpack --mode development --watch",
     "build": "webpack --mode production"
   },

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { TOKEN_TYPE } from '@/utils/constants';
 import { verifyJWT } from '@/utils/utils';
 
-const instance = axios.create();
+const instance = axios.create({ timeout: 4000 });
 
 if (process.env.MODE !== 'dev') {
   instance.defaults.baseURL = process.env.BASE_URL;

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -50,4 +50,21 @@ instance.interceptors.request.use(
   },
 );
 
+instance.interceptors.response.use(
+  (res) => {
+    if (res.status >= 400) {
+      console.error('api 요청 실패', res);
+    }
+    return res;
+  },
+  (err) => {
+    if (axios.isCancel(err)) {
+      console.log('요청 취소', err);
+    } else {
+      console.error('api 에러', err);
+    }
+    return Promise.reject(err);
+  },
+);
+
 export default instance;

--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -16,6 +16,8 @@ const Container = styled.div`
   overflow-y: auto;
 `;
 
+const Bottom = styled.div``;
+
 interface RightSideParams {
   channelId: string | undefined;
 }
@@ -24,17 +26,10 @@ const ThreadList = () => {
   const { channelId }: RightSideParams = useParams();
   const { threadList } = useThreadState();
   const dispatch = useDispatch();
-  const ref = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
-  /* 
-    TODO: 
-    스크롤이 끝까지 가도록 변경(현재 어중간하게 이동함), 
-    아이템 추가할 때는 스크롤하지 않도록 변경(위에꺼 보는게 새 메시지가 와도 맨 밑으로 스크롤 될 필요 x)
-  */
   useEffect(() => {
-    ref.current?.scrollTo({
-      top: ref.current?.getBoundingClientRect().bottom,
-    });
+    bottomRef.current?.scrollIntoView();
   }, [threadList]);
 
   useEffect(() => {
@@ -44,7 +39,7 @@ const ThreadList = () => {
   }, [dispatch, channelId]);
 
   return (
-    <Container ref={ref}>
+    <Container>
       {threadList?.map((thread: Thread, index: number) => (
         <ThreadItem
           key={thread.id}
@@ -52,6 +47,7 @@ const ThreadList = () => {
           prevThreadUserId={threadList[index - 1]?.userId}
         />
       ))}
+      <Bottom ref={bottomRef} />
     </Container>
   );
 };

--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import { getThreadRequest } from '@/store/modules/thread.slice';
+import { getThreadRequest, setScrollable } from '@/store/modules/thread.slice';
 import styled from 'styled-components';
 import { Thread } from '@/types';
 import { ThreadItem } from '@/components';
@@ -24,13 +24,17 @@ interface RightSideParams {
 
 const ThreadList = () => {
   const { channelId }: RightSideParams = useParams();
-  const { threadList } = useThreadState();
+  const { threadList, canScroll } = useThreadState();
   const { userInfo } = useUserState();
   const dispatch = useDispatch();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (threadList) {
+    if (threadList && threadList.length) {
+      if (canScroll) {
+        bottomRef.current?.scrollIntoView();
+        dispatch(setScrollable({ canScroll: false }));
+      }
       if (threadList[threadList.length - 1].userId === userInfo?.id) {
         bottomRef.current?.scrollIntoView();
       }

--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -4,7 +4,7 @@ import { getThreadRequest } from '@/store/modules/thread.slice';
 import styled from 'styled-components';
 import { Thread } from '@/types';
 import { ThreadItem } from '@/components';
-import { useThreadState } from '@/hooks';
+import { useThreadState, useUserState } from '@/hooks';
 import { useParams } from 'react-router-dom';
 import { isNumberTypeValue } from '@/utils/utils';
 
@@ -25,11 +25,16 @@ interface RightSideParams {
 const ThreadList = () => {
   const { channelId }: RightSideParams = useParams();
   const { threadList } = useThreadState();
+  const { userInfo } = useUserState();
   const dispatch = useDispatch();
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView();
+    if (threadList) {
+      if (threadList[threadList.length - 1].userId === userInfo?.id) {
+        bottomRef.current?.scrollIntoView();
+      }
+    }
   }, [threadList]);
 
   useEffect(() => {

--- a/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ThreadListHeader.tsx
@@ -9,6 +9,11 @@ import { loadChannelRequest, modifyLastChannelRequest } from '@/store/modules/ch
 import { DimModal, LockIcon, PoundIcon, WarningIcon, AddUserIcon } from '@/components';
 import theme from '@/styles/theme';
 import { flex, hoverActive } from '@/styles/mixin';
+import {
+  sendMessageRequest,
+  enterRoomRequest,
+  leaveRoomRequest,
+} from '@/store/modules/socket.slice';
 import { AddUsersModalHeader, AddUsersModalBody } from './ChannelModal/AddUsersModal';
 import { AddTopicModalHeader, AddTopicModalBody } from './ChannelModal/AddTopicModal';
 import { ShowUsersModalHeader, ShowUsersModalBody } from './ChannelModal/ShowUsersModal';
@@ -108,6 +113,17 @@ const ThreadListHeader = () => {
       dispatch(modifyLastChannelRequest({ lastChannelId: +channelId, userId: userInfo.id }));
     }
   }, [channelId]);
+
+  useEffect(() => {
+    if (current) {
+      dispatch(enterRoomRequest({ room: current.name }));
+    }
+    return () => {
+      if (current) {
+        dispatch(leaveRoomRequest({ room: current.name }));
+      }
+    };
+  }, [current]);
 
   const clickShowUsersModal = () => {
     setShowUsersModalVisible((state) => !state);

--- a/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
+++ b/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
@@ -4,7 +4,7 @@ import { createThreadRequest, addThread } from '@/store/modules/thread.slice';
 import { sendMessageRequest } from '@/store/modules/socket.slice';
 import { useParams } from 'react-router-dom';
 import { useChannelState, useUserState } from '@/hooks';
-import { INPUT_BOX_TYPE, USER_DEFAULT_PROFILE_URL } from '@/utils/constants';
+import { INPUT_BOX_TYPE, USER_DEFAULT_PROFILE_URL, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
 import { PaperPlaneIcon } from '@/components';
 import { SubmitButton as SB } from '@/styles/shared';
 import styled from 'styled-components';
@@ -146,14 +146,13 @@ const ThreadInputBox: React.FC<ThreadInputBoxProps> = ({ inputBoxType }: ThreadI
   const sendMessage = () => {
     if (userInfo) {
       const thread = {
-        displayName: 'J020_권현준',
-        phoneNumber: '010-4999-9994',
-        image: USER_DEFAULT_PROFILE_URL,
-        email: 'rnjshippo@naver.com',
-        id: Math.floor(Math.random() * 1000),
-        userId: 1,
-        channelId: 1,
-        content: `this is my content ${Math.floor(Math.random() * 1000)}`,
+        userId: userInfo.id,
+        displayName: userInfo.displayName,
+        phoneNumber: userInfo.phoneNumber,
+        image: userInfo.image,
+        email: userInfo.email,
+        channelId: current?.id as number,
+        content: comment,
         url: 'this is url',
         isEdited: 0,
         isPinned: 0,
@@ -164,19 +163,14 @@ const ThreadInputBox: React.FC<ThreadInputBoxProps> = ({ inputBoxType }: ThreadI
         subThreadUserId1: null,
         subThreadUserId2: null,
         subThreadUserId3: null,
-        createdAt: '2020-12-06',
-        updatedAt: '2020-12-06',
       };
-      // dispatch(addThread({ thread }));
-      dispatch(sendMessageRequest({ thread }));
-      // dispatch(
-      //   createThreadRequest({
-      //     content: comment,
-      //     userId: +userInfo.id,
-      //     channelId: +(channelId as string),
-      //     parentId,
-      //   }),
-      // );
+      dispatch(
+        sendMessageRequest({
+          type: SOCKET_MESSAGE_TYPE.THREAD,
+          thread,
+          room: current?.name as string,
+        }),
+      );
     }
   };
 

--- a/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
+++ b/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
@@ -1,10 +1,9 @@
 import React, { useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { createThreadRequest, addThread } from '@/store/modules/thread.slice';
 import { sendMessageRequest } from '@/store/modules/socket.slice';
 import { useParams } from 'react-router-dom';
 import { useChannelState, useUserState } from '@/hooks';
-import { INPUT_BOX_TYPE, USER_DEFAULT_PROFILE_URL, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
+import { INPUT_BOX_TYPE, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
 import { PaperPlaneIcon } from '@/components';
 import { SubmitButton as SB } from '@/styles/shared';
 import styled from 'styled-components';

--- a/client/src/store/modules/socket.slice.ts
+++ b/client/src/store/modules/socket.slice.ts
@@ -3,7 +3,7 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '@/store/modules';
 import { Socket } from '@/store/sagas/socketSaga';
-import { Thread } from '@/types';
+import { RoomEvent, SocketEvent } from '@/types';
 
 interface SocketState {
   socket: Socket | null;
@@ -24,8 +24,10 @@ const socketSlice = createSlice({
     socketConnectFailure(state, { payload }: PayloadAction<{ err: Error }>) {
       console.error('socket connection failure', payload.err);
     },
-    sendMessageRequest(state, { payload }: PayloadAction<{ thread: Thread }>) {},
+    sendMessageRequest(state, { payload }: PayloadAction<SocketEvent>) {},
     socketDisconnectRequest() {},
+    enterRoomRequest(state, { payload }: PayloadAction<RoomEvent>) {},
+    leaveRoomRequest(state, { payload }: PayloadAction<RoomEvent>) {},
   },
 });
 
@@ -39,6 +41,8 @@ export const {
   socketConnectFailure,
   sendMessageRequest,
   socketDisconnectRequest,
+  enterRoomRequest,
+  leaveRoomRequest,
 } = socketSlice.actions;
 
 export default socketSlice.reducer;

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -8,7 +8,7 @@ interface ThreadList {
 }
 
 const threadListState: ThreadList = {
-  threadList: [initialThread],
+  threadList: null,
 };
 
 export interface getThreadRequestPayload {

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -3,12 +3,14 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Thread, initialThread, ThreadResponse } from '@/types';
 
-interface ThreadList {
+interface ThreadState {
   threadList: Thread[] | null;
+  canScroll: boolean;
 }
 
-const threadListState: ThreadList = {
+const threadListState: ThreadState = {
   threadList: null,
+  canScroll: false,
 };
 
 export interface getThreadRequestPayload {
@@ -28,8 +30,9 @@ const threadSlice = createSlice({
   initialState: threadListState,
   reducers: {
     getThreadRequest(state, action: PayloadAction<getThreadRequestPayload>) {},
-    getThreadSuccess(state, action: PayloadAction<ThreadList>) {
+    getThreadSuccess(state, action: PayloadAction<ThreadState>) {
       state.threadList = action.payload.threadList;
+      state.canScroll = action.payload.canScroll;
     },
     getThreadFailure(state, action) {},
     createThreadRequest(state, action: PayloadAction<createThreadRequestPayload>) {},
@@ -41,6 +44,9 @@ const threadSlice = createSlice({
       } else {
         state.threadList = [action.payload.thread];
       }
+    },
+    setScrollable(state, { payload }: PayloadAction<{ canScroll: boolean }>) {
+      state.canScroll = payload.canScroll;
     },
   },
 });
@@ -54,6 +60,7 @@ export const {
   createThreadSuccess,
   createThreadFailure,
   addThread,
+  setScrollable,
 } = threadSlice.actions; // action 나눠서 export 하기
 
 export default threadSlice.reducer;

--- a/client/src/store/sagas/threadSaga.ts
+++ b/client/src/store/sagas/threadSaga.ts
@@ -14,7 +14,7 @@ import { threadService } from '@/services/thread.service';
 function* getThreadList({ channelId }: getThreadRequestPayload) {
   try {
     const result = yield call(threadService.getThreadList, { channelId });
-    yield put(getThreadSuccess({ threadList: result.data.threadList }));
+    yield put(getThreadSuccess({ threadList: result.data.threadList, canScroll: true }));
   } catch (err) {
     yield put(getThreadFailure(err));
   }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -5,3 +5,4 @@ export * from './channelInfo';
 export * from './joinedUser';
 export * from './channel';
 export * from './service';
+export * from './socket';

--- a/client/src/types/socket.ts
+++ b/client/src/types/socket.ts
@@ -1,0 +1,112 @@
+import { SOCKET_MESSAGE_TYPE } from '@/utils/constants';
+
+interface Emoji {
+  name: string;
+  userId: number;
+}
+interface Thread {
+  id?: number; // 스레드 생성 요청 이벤트에는 id가 없음
+  userId: number;
+  channelId: number;
+  parentId: number | null;
+  content: string;
+  url: string;
+  isEdited: number;
+  isPinned: number;
+  createdAt?: string; // 생성 요청시에 없음
+  updatedAt?: string; // 생성 요청시에 없음
+  emoji: Emoji[] | null;
+  subCount: number;
+  subThreadUserId1: number | null;
+  subThreadUserId2: number | null;
+  subThreadUserId3: number | null;
+  email: string;
+  displayName: string;
+  phoneNumber: string | null;
+  image: string;
+}
+
+interface User {
+  id: number;
+  email: string;
+  displayName: string;
+  phoneNumber: string;
+  image: string;
+  isDeleted: number;
+  lastChannelId?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface Channel {
+  id: number;
+  ownerId: number;
+  name: string;
+  channelType: number;
+  topic: string;
+  isPublic: number;
+  isDeleted: number;
+  memberCount: number;
+  description: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+type DM = Channel;
+
+export interface ThreadEvent {
+  type: string;
+  room: string;
+  thread: Thread;
+}
+
+export interface EmojiEvent {
+  type: string;
+  room: string;
+  emoji: Emoji; // TODO: 추후 타입 다시 결정
+}
+
+export interface UserEvent {
+  type: string;
+  user: User;
+}
+
+export interface ChannelEvent {
+  type: string;
+  channel: Channel;
+}
+
+export interface DMEvent {
+  type: string;
+  dm: DM;
+}
+
+export interface RoomEvent {
+  room: string;
+}
+
+export type SocketEvent = ThreadEvent | EmojiEvent | UserEvent | ChannelEvent | DMEvent | RoomEvent;
+
+export const isThreadEvent = (event: SocketEvent): event is ThreadEvent => {
+  return (event as ThreadEvent).type === SOCKET_MESSAGE_TYPE.THREAD;
+};
+
+export const isEmojiEvent = (event: SocketEvent): event is EmojiEvent => {
+  return (event as EmojiEvent).type === SOCKET_MESSAGE_TYPE.EMOJI;
+};
+
+export const isUserEvent = (event: SocketEvent): event is UserEvent => {
+  return (event as UserEvent).type === SOCKET_MESSAGE_TYPE.USER;
+};
+
+export const isChannelEvent = (event: SocketEvent): event is ChannelEvent => {
+  return (event as ChannelEvent).type === SOCKET_MESSAGE_TYPE.CHANNEL;
+};
+
+export const isDMEvent = (event: SocketEvent): event is DMEvent => {
+  return (event as DMEvent).type === SOCKET_MESSAGE_TYPE.DM;
+};
+
+export const isRoomEvent = (event: SocketEvent): event is RoomEvent => {
+  return (event as RoomEvent).room !== undefined;
+};

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -42,3 +42,11 @@ export const SOCKET_EVENT_TYPE = {
   ENTER_ROOM: 'enter_room',
   LEAVE_ROOM: 'leave_room',
 };
+
+export const SOCKET_MESSAGE_TYPE = {
+  THREAD: 'thread',
+  EMOJI: 'emoji',
+  USER: 'user',
+  CHANNEL: 'channel',
+  DM: 'dm',
+};

--- a/server/src/models/thread.model.ts
+++ b/server/src/models/thread.model.ts
@@ -36,7 +36,7 @@ export const threadModel = {
     userId: number;
     channelId: number;
     content: string;
-    parentId: number;
+    parentId: number | null;
     url: string;
   }): any {
     const sql = `INSERT INTO thread (user_id, channel_id, content, parent_id, url) VALUES (?,?,?,?,?)`;

--- a/server/src/models/thread.model.ts
+++ b/server/src/models/thread.model.ts
@@ -1,7 +1,7 @@
 import pool from '@/db';
 
 export const threadModel = {
-  getThreadListInChannel(channelId: number): any {
+  getThreadListInChannel({ channelId }: { channelId: number }): any {
     const sql = `SELECT thread.id AS id, user_id AS userId, channel_id AS channelId, content, url, is_edited AS isEdited, is_pinned AS isPinned, 
     thread.is_deleted AS isDeleted, parent_id AS parentId, emoji, thread.created_at AS createdAt, sub_count AS subCount, sub_thread_user_id_1 AS subThreadUserId1, 
     sub_thread_user_id_2 AS subThreadUserId2, sub_thread_user_id_3 AS subThreadUserId3,  
@@ -10,7 +10,7 @@ export const threadModel = {
     WHERE channel_id=? AND parent_id is null AND thread.is_deleted=0;`;
     return pool.execute(sql, [channelId]);
   },
-  getSubThreadList(threadId: number): any {
+  getSubThreadList({ threadId }: { threadId: number }): any {
     const sql = `SELECT thread.id, user_id AS userId, channel_id AS channelId, content, url, is_edited AS isEdited, is_pinned AS isPinned, 
     thread.is_deleted AS isDeleted, parent_id AS parentId, emoji, thread.created_at AS createdAt, sub_count AS subCount, sub_thread_user_id_1 AS subThreadUserId1, sub_thread_user_id_2 AS subThreadUserId2, sub_thread_user_id_3 AS subThreadUserId3, 
     email, display_name AS displayName, phone_number AS phoneNumber, image
@@ -18,7 +18,7 @@ export const threadModel = {
     WHERE parent_id=? AND thread.is_deleted=0;`;
     return pool.execute(sql, [threadId]);
   },
-  getThread(threadId: number): any {
+  getThread({ threadId }: { threadId: number }): any {
     const sql = `SELECT thread.id AS id, user_id AS userId, channel_id AS channelId, content, url, is_edited AS isEdited, is_pinned AS isPinned, 
     thread.is_deleted AS isDeleted, parent_id AS parentId, emoji, thread.created_at AS createdAt, sub_count AS subCount, sub_thread_user_id_1 AS subThreadUserId1, sub_thread_user_id_2 AS subThreadUserId2, sub_thread_user_id_3 AS subThreadUserId3, 
     email, display_name AS displayName, phone_number AS phoneNumber, image
@@ -26,29 +26,43 @@ export const threadModel = {
     WHERE thread.id=? AND thread.is_deleted=0;`;
     return pool.execute(sql, [threadId]);
   },
-  createThread(
-    userId: number,
-    channelId: number,
-    content: string,
-    parentId: number,
-    url: string,
-  ): any {
+  createThread({
+    userId,
+    channelId,
+    content,
+    parentId,
+    url,
+  }: {
+    userId: number;
+    channelId: number;
+    content: string;
+    parentId: number;
+    url: string;
+  }): any {
     const sql = `INSERT INTO thread (user_id, channel_id, content, parent_id, url) VALUES (?,?,?,?,?)`;
     return pool.execute(sql, [userId, channelId, content, parentId, url]);
   },
-  updateSubCountOfThread(parentId: number): any {
+  updateSubCountOfThread({ parentId }: { parentId: number }): any {
     const sql = `UPDATE thread SET sub_count=sub_count+1 WHERE id=?;`;
     return pool.execute(sql, [parentId]);
   },
-  updateSubThreadUserIdOfThread(updateIndex: number, userId: number, parentId: number): any {
+  updateSubThreadUserIdOfThread({
+    updateIndex,
+    userId,
+    parentId,
+  }: {
+    updateIndex: number;
+    userId: number;
+    parentId: number;
+  }): any {
     const sql = `UPDATE thread SET sub_thread_user_id_${updateIndex}=? WHERE id=?;`;
     return pool.execute(sql, [userId, parentId]);
   },
-  updateThread(content: string, threadId: number): any {
+  updateThread({ content, threadId }: { content: string; threadId: number }): any {
     const sql = `UPDATE thread SET content=? WHERE id=?;`;
     return pool.execute(sql, [content, threadId]);
   },
-  deleteThread(threadId: number): any {
+  deleteThread({ threadId }: { threadId: number }): any {
     const sql = `UPDATE thread SET is_deleted=1 WHERE id=?;`;
     return pool.execute(sql, [threadId]);
   },

--- a/server/src/routes/api/channels/[channelId]/channelId.controller.ts
+++ b/server/src/routes/api/channels/[channelId]/channelId.controller.ts
@@ -29,7 +29,7 @@ export const inviteChannel = async (req: Request, res: Response, next: NextFunct
     return;
   }
   if (verifyRequestData([users, channelId])) {
-    const joinUsers: Array<Array<number>> = users.reduce((acc: Array<Array<number>>, cur: User) => {
+    const joinUsers: [number[]] = users.reduce((acc: [number[]], cur: User) => {
       acc.push([cur.id, +channelId]);
       return acc;
     }, []);

--- a/server/src/routes/api/channels/channels.controller.ts
+++ b/server/src/routes/api/channels/channels.controller.ts
@@ -22,7 +22,7 @@ export const createChannel = async (req: Request, res: Response, next: NextFunct
       isPublic,
       description,
     });
-    res.status(200).json({ channel });
+    res.status(201).json({ channel });
     return;
   }
   res.status(400).json({ message: '필수 값 누락' });

--- a/server/src/routes/api/threads/[threadId]/threadId.controller.ts
+++ b/server/src/routes/api/threads/[threadId]/threadId.controller.ts
@@ -17,8 +17,8 @@ export const getSubThread = async (
     return;
   }
   try {
-    const [parentThread] = await threadModel.getThread(Number(threadId));
-    const [subThreadList] = await threadModel.getSubThreadList(Number(threadId));
+    const [parentThread] = await threadModel.getThread({ threadId: +threadId });
+    const [subThreadList] = await threadModel.getSubThreadList({ threadId: +threadId });
     res.json({ parentThread, subThreadList });
   } catch (err) {
     next(err);
@@ -39,7 +39,7 @@ export const modifyThread = async (
 
   if (verifyRequestData([content])) {
     try {
-      const [result] = await threadModel.updateThread(content, Number(threadId));
+      const [result] = await threadModel.updateThread({ content, threadId: +threadId });
       res.status(200).json({ result });
       return;
     } catch (err) {
@@ -61,7 +61,7 @@ export const deleteThread = async (
   const { threadId } = req.params;
   if (verifyRequestData([threadId])) {
     try {
-      const [result] = await threadModel.deleteThread(Number(threadId));
+      const [result] = await threadModel.deleteThread({ threadId: +threadId });
       res.status(200).json({ result });
       return;
     } catch (err) {

--- a/server/src/routes/api/threads/threads.controller.ts
+++ b/server/src/routes/api/threads/threads.controller.ts
@@ -17,7 +17,13 @@ export const createThread = async (
     // userId, channelId, content, parentId 이상한값 예외처리 추후 추가
     try {
       const url = 'temp/url'; // 추후 url 생성 부분 추가
-      const [result] = await threadModel.createThread(userId, channelId, content, parentId, url);
+      const [result] = await threadModel.createThread({
+        userId,
+        channelId,
+        content,
+        parentId,
+        url,
+      });
       // 1. threadCount 변경 2. subThread 추가 로직 구현
       /*
       1. parentId가 true면, parentId의 subCount 값 +1
@@ -30,7 +36,7 @@ export const createThread = async (
       */
       if (parentId) {
         await threadModel.updateSubCountOfThread(parentId);
-        const [[parentThread]] = await threadModel.getThread(Number(parentId));
+        const [[parentThread]] = await threadModel.getThread({ threadId: +parentId });
         const subThreadUserIdList: number[] = [
           parentThread.subThreadUserId1,
           parentThread.subThreadUserId2,
@@ -43,7 +49,11 @@ export const createThread = async (
           );
           // null인 자리가 있으면,
           if (updateIndex !== -1) {
-            await threadModel.updateSubThreadUserIdOfThread(updateIndex + 1, userId, parentId);
+            await threadModel.updateSubThreadUserIdOfThread({
+              updateIndex: updateIndex + 1,
+              userId,
+              parentId,
+            });
           }
         }
       }
@@ -70,7 +80,7 @@ export const getChannelThreads = async (
     return;
   }
   try {
-    const [threadList] = await threadModel.getThreadListInChannel(Number(channelId));
+    const [threadList] = await threadModel.getThreadListInChannel({ channelId: +channelId });
 
     res.json({ threadList });
   } catch (err) {

--- a/server/src/routes/api/threads/threads.controller.ts
+++ b/server/src/routes/api/threads/threads.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { verifyRequestData } from '@/utils/utils';
 import { threadModel } from '@/models';
 import { ERROR_MESSAGE } from '@/utils/constants';
+import { threadService } from '@/services';
 
 /**
  * 쓰레드 추가
@@ -16,48 +17,8 @@ export const createThread = async (
   if (verifyRequestData([userId, channelId, content]) && parentId !== undefined) {
     // userId, channelId, content, parentId 이상한값 예외처리 추후 추가
     try {
-      const url = 'temp/url'; // 추후 url 생성 부분 추가
-      const [result] = await threadModel.createThread({
-        userId,
-        channelId,
-        content,
-        parentId,
-        url,
-      });
-      // 1. threadCount 변경 2. subThread 추가 로직 구현
-      /*
-      1. parentId가 true면, parentId의 subCount 값 +1
-      - await threadModel.updateSubCountOfThread(parentId);
-      - UPDATE thread SET sub_count +1 WHERE id = ?(parent_id);
-      2. parentId의 sub_thread_user_id 1,2,3이 null이고, 1,2,3에 해당 userId가 없으면 userId를 null에 추가.
-      - sub_thread_user_id를 돌면서, 값이 있을때 existSubThreadUserIdList에 userId를 넣고, 
-      없으면 existSubThreadUserIdList에 현재 userId값이 있는지 비교한 후, 있으면 넘어가고 없으면 update.
-      - SELECT sub_thread_user_id_1, sub_thread_user_id_2, sub_thread_user_id_3 FROM thread 
-      */
-      if (parentId) {
-        await threadModel.updateSubCountOfThread(parentId);
-        const [[parentThread]] = await threadModel.getThread({ threadId: +parentId });
-        const subThreadUserIdList: number[] = [
-          parentThread.subThreadUserId1,
-          parentThread.subThreadUserId2,
-          parentThread.subThreadUserId3,
-        ];
-
-        if (!subThreadUserIdList.find((subThreadUserId) => subThreadUserId === userId)) {
-          const updateIndex = subThreadUserIdList.findIndex(
-            (subThreadUserId) => subThreadUserId === null,
-          );
-          // null인 자리가 있으면,
-          if (updateIndex !== -1) {
-            await threadModel.updateSubThreadUserIdOfThread({
-              updateIndex: updateIndex + 1,
-              userId,
-              parentId,
-            });
-          }
-        }
-      }
-      res.status(201).json({ result });
+      const threadId = await threadService.createThread({ userId, channelId, content, parentId });
+      res.status(201).json({ threadId });
       return;
     } catch (err) {
       next(err);

--- a/server/src/routes/api/users/[userId]/userId.controller.ts
+++ b/server/src/routes/api/users/[userId]/userId.controller.ts
@@ -128,13 +128,14 @@ export const modifyLastChannel = async (
 ): Promise<void> => {
   const { userId } = req.params;
   const { lastChannelId } = req.body;
-  if (Number.isNaN(+userId)) {
-    next({ message: ERROR_MESSAGE.WRONG_PARAMS, status: 400 });
-    return;
-  }
   if (verifyRequestData([lastChannelId])) {
-    await userModel.modifyLastChannel({ lastChannelId, userId: +userId });
-    return;
+    try {
+      await userModel.modifyLastChannel({ lastChannelId, userId: +userId });
+      res.status(200).end();
+    } catch (err) {
+      next(err);
+      return;
+    }
   }
   res.status(400).json({ message: ERROR_MESSAGE.MISSING_REQUIRED_VALUES });
 };

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,0 +1,1 @@
+export * from './thread.service';

--- a/server/src/services/thread.service.ts
+++ b/server/src/services/thread.service.ts
@@ -1,0 +1,60 @@
+import { threadModel } from '@/models';
+
+interface CreateThreadParams {
+  userId: number;
+  channelId: number;
+  content: string;
+  parentId: number | null;
+}
+
+export const threadService = {
+  async createThread({
+    userId,
+    channelId,
+    content,
+    parentId,
+  }: CreateThreadParams): Promise<number> {
+    const url = 'temp/url'; // 추후 url 생성 부분 추가
+    const [{ insertId }] = await threadModel.createThread({
+      userId,
+      channelId,
+      content,
+      parentId,
+      url,
+    });
+    // 1. threadCount 변경 2. subThread 추가 로직 구현
+    /*
+      1. parentId가 true면, parentId의 subCount 값 +1
+      - await threadModel.updateSubCountOfThread(parentId);
+      - UPDATE thread SET sub_count +1 WHERE id = ?(parent_id);
+      2. parentId의 sub_thread_user_id 1,2,3이 null이고, 1,2,3에 해당 userId가 없으면 userId를 null에 추가.
+      - sub_thread_user_id를 돌면서, 값이 있을때 existSubThreadUserIdList에 userId를 넣고, 
+      없으면 existSubThreadUserIdList에 현재 userId값이 있는지 비교한 후, 있으면 넘어가고 없으면 update.
+      - SELECT sub_thread_user_id_1, sub_thread_user_id_2, sub_thread_user_id_3 FROM thread 
+      */
+    if (parentId) {
+      await threadModel.updateSubCountOfThread({ parentId: +parentId });
+      const [[parentThread]] = await threadModel.getThread({ threadId: +parentId });
+      const subThreadUserIdList: number[] = [
+        parentThread.subThreadUserId1,
+        parentThread.subThreadUserId2,
+        parentThread.subThreadUserId3,
+      ];
+
+      if (!subThreadUserIdList.find((subThreadUserId) => subThreadUserId === userId)) {
+        const updateIndex = subThreadUserIdList.findIndex(
+          (subThreadUserId) => subThreadUserId === null,
+        );
+        // null인 자리가 있으면,
+        if (updateIndex !== -1) {
+          await threadModel.updateSubThreadUserIdOfThread({
+            updateIndex: updateIndex + 1,
+            userId,
+            parentId,
+          });
+        }
+      }
+    }
+    return insertId;
+  },
+};

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -32,3 +32,11 @@ export const SOCKET_EVENT_TYPE = {
   ENTER_ROOM: 'enter_room',
   LEAVE_ROOM: 'leave_room',
 };
+
+export const SOCKET_MESSAGE_TYPE = {
+  THREAD: 'thread',
+  EMOJI: 'emoji',
+  USER: 'user',
+  CHANNEL: 'channel',
+  DM: 'dm',
+};


### PR DESCRIPTION
## 구현 내용

### 1. 소켓 컨벤션 정의
- [x] 서버 디렉토리의 lib/socket.ts 파일에 컨벤션과 타입을 모두 넣어놨습니다.
- 우선 저기서 작업하고 컨벤션 확정되면, 필요에 따라 별도 파일로 분리하도록 할게요

### 2. room 접속/나가기 구현
- [x] 우선 ThreadListHeader 컴포넌트가 mount될 때, room에 접속하고, unmount될 때 leave 하는 방식으로 구현했습니다.
- 서브 스레드는 room에 접속할 필요가 없을 것 같기도해서 그 부분은 놔뒀습니다. 
  - (채널 룸 안에서 한번에 처리될 것 같아서 고민좀 해보겠습니다.)

### 3. thread.model 파일 매개변수 수정
- [x] 객체 타입으로 모두 수정했습니다.

### 4. thread 생성 코드 service 코드로 분리
- [x] 스레드 생성하는 로직을 socket에서도 써야해서  thread.service 파일로 분리했습니다.

### 5. 채널 접속 시 스크롤 최 하단으로 이동
- [x] 채널에 접속하면 최초 mount될 때 스크롤을 맨 밑으로 내립니다.
- [x] 채널에 내가 채팅을 쓰면 맨 밑으로 내립니다. (상대의 채팅으로는 내려가지 않음)

### 6. last-channel 응답 수정
- [x] 응답이 없어서 응답을 넣었습니다.

### 7. axios timeount 시간 지정
- [x] 타임아웃을 안주니깐 무한하게 기다리네요. 앞에서 last-channel이 응답을 안하는걸 여기서 무한히 기다려서 일욜과 같은 무한대기가 발생했습니다.

### 8. 채널 saga의 로직 리팩토링
- [x] 우선 get 요청에 대해 takeLatest로 잘못받는부분은 every로 바꿨습니다.
- [x] 그 외에 status를 확인하는 코드가 없어서 모두 넣었습니다.

### 9. 채널 생성 api 응답 수정
- [x] 200 -> 201로 바꿨습니다.

### 10. axios response interceptor
- [x] 에러 응답(300이상) 일 때 공통으로 로그를 찍도록 했습니다.

### 11. webpack --progress 표시
- [x] 빌드가 오래걸려서 심심하실까봐 넣어드렸습니다. 🙂

