### PR TITLE
dm방 만드는 것을 소켓으로 구현

### DIFF
--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
@@ -149,7 +149,7 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
       const name = makeDMRoomName(pickUsers, userInfo.displayName);
 
       const users: JoinedUser[] = pickUsers.reduce(
-        (acc: any, cur) => {
+        (acc: JoinedUser[], cur) => {
           acc.push({ userId: cur.id, displayName: cur.displayName, image: cur.image });
           return acc;
         },

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
@@ -3,14 +3,12 @@ import styled from 'styled-components';
 import { flex } from '@/styles/mixin';
 import { matchUsersRequest } from '@/store/modules/user.slice';
 import { useChannelState, useUserState } from '@/hooks';
-import { createChannelRequest } from '@/store/modules/channel.slice';
 import { sendMessageRequest } from '@/store/modules/socket.slice';
 import { JoinedUser, User } from '@/types';
 import { CHANNEL_SUBTYPE, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { makeDMRoomName } from '@/utils/utils';
-import { Channel } from 'redux-saga';
 
 interface Props {
   visible: boolean;

--- a/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
+++ b/client/src/components/ThreadListBox/ThreadListHeader/ChannelModal/AddUsersModal/AddUsersModalBody/AddUsersModalBody.tsx
@@ -5,11 +5,12 @@ import { matchUsersRequest } from '@/store/modules/user.slice';
 import { useChannelState, useUserState } from '@/hooks';
 import { createChannelRequest } from '@/store/modules/channel.slice';
 import { sendMessageRequest } from '@/store/modules/socket.slice';
-import { User } from '@/types';
+import { JoinedUser, User } from '@/types';
 import { CHANNEL_SUBTYPE, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { makeDMRoomName } from '@/utils/utils';
+import { Channel } from 'redux-saga';
 
 interface Props {
   visible: boolean;
@@ -149,15 +150,30 @@ const AddUsersModalBody: React.FC<AddUsersModalBodyProps> = ({
     } else if (userInfo) {
       const name = makeDMRoomName(pickUsers, userInfo.displayName);
 
+      const users: JoinedUser[] = pickUsers.reduce(
+        (acc: any, cur) => {
+          acc.push({ userId: cur.id, displayName: cur.displayName, image: cur.image });
+          return acc;
+        },
+        [{ userId: userInfo.id, displayName: userInfo.displayName, image: userInfo.image }],
+      );
+
+      const channel = {
+        ownerId: userInfo.id,
+        name,
+        channelType: 2,
+        topic: '',
+        isPublic: 0,
+        memberCount: 0,
+        description: '',
+      };
+
       dispatch(
-        createChannelRequest({
-          ownerId: userInfo?.id,
-          channelType: 2,
-          isPublic: false,
-          name,
-          description: '',
-          displayName: '',
-          users: [userInfo, ...pickUsers],
+        sendMessageRequest({
+          type: SOCKET_MESSAGE_TYPE.CHANNEL,
+          subType: CHANNEL_SUBTYPE.MAKE_DM,
+          channel,
+          users,
         }),
       );
     }

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -14,6 +14,7 @@ import {
   updateChannelUnread,
   updateChannelTopic,
   updateChannelUsers,
+  setReloadMyChannelListFlag,
 } from '@/store/modules/channel.slice';
 import io from 'socket.io-client';
 import { eventChannel } from 'redux-saga';
@@ -83,6 +84,10 @@ function subscribeSocket(socket: Socket) {
         if (subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS) {
           emit(updateChannelUsers({ users: users as JoinedUser[], channel: channel as Channel }));
           return;
+        }
+
+        if (subType === CHANNEL_SUBTYPE.MAKE_DM) {
+          emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
         }
 
         return;

--- a/client/src/types/socket.ts
+++ b/client/src/types/socket.ts
@@ -44,7 +44,7 @@ interface User {
 }
 
 interface Channel {
-  id: number;
+  id?: number;
   ownerId: number;
   name: string;
   channelType: number;
@@ -81,7 +81,7 @@ export interface ChannelEvent {
   subType: string;
   channel?: Channel;
   users?: JoinedUser[];
-  room: string;
+  room?: string;
 }
 
 export interface DMEvent {

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -56,4 +56,5 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_TOPIC: 'update_channel_topic',
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
+  MAKE_DM: 'make_dm',
 };

--- a/server/src/lib/socket.ts
+++ b/server/src/lib/socket.ts
@@ -214,9 +214,9 @@ export const bindSocketServer = (server: http.Server): void => {
 
         if (subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_TOPIC) {
           try {
-            if (channel && room) {
+            if (channel?.id && room) {
               await channelModel.modifyTopic({
-                channelId: channel.id as number,
+                channelId: channel.id,
                 topic: channel.topic,
               });
               namespace.to(room).emit(MESSAGE, {
@@ -233,7 +233,7 @@ export const bindSocketServer = (server: http.Server): void => {
         }
 
         if (subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS) {
-          if (channel && users) {
+          if (channel?.id && users) {
             try {
               const joinUsers: [number[]] = users.reduce((acc: any, cur: JoinedUser) => {
                 acc.push([cur.userId, channel.id]);
@@ -243,10 +243,10 @@ export const bindSocketServer = (server: http.Server): void => {
               await channelModel.joinChannel({
                 joinUsers,
                 prevMemberCount: channel.memberCount,
-                channelId: channel.id as number,
+                channelId: channel.id,
               });
               const [joinedUsers] = await channelModel.getChannelUser({
-                channelId: channel.id as number,
+                channelId: channel.id,
               });
 
               namespace.emit(MESSAGE, {
@@ -264,16 +264,9 @@ export const bindSocketServer = (server: http.Server): void => {
         }
 
         if (subType === CHANNEL_SUBTYPE.MAKE_DM) {
-          if (users) {
+          if (users && channel) {
             try {
-              const {
-                ownerId,
-                name,
-                memberCount,
-                isPublic,
-                description,
-                channelType,
-              } = channel as Channel;
+              const { ownerId, name, memberCount, isPublic, description, channelType } = channel;
 
               const [newChannel] = await channelModel.createChannel({
                 ownerId,

--- a/server/src/models/channels.model.ts
+++ b/server/src/models/channels.model.ts
@@ -76,4 +76,12 @@ export const channelModel = {
     const sql = 'UPDATE channel SET topic = ? WHERE id = ?';
     return pool.execute(sql, [topic, channelId]);
   },
+  getNotJoinedChannels({ userId }: { userId: number }): any {
+    const sql = `SELECT * FROM channel
+    WHERE channel.is_public = 1 AND channel.id NOT IN
+    (SELECT channel.id FROM channel 
+    JOIN user_channel 
+    WHERE user_channel.user_id = ? AND channel.id = user_channel.channel_id)`;
+    return pool.execute(sql, [userId]);
+  },
 };

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -46,4 +46,5 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_TOPIC: 'update_channel_topic',
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
+  MAKE_DM: 'make_dm',
 };


### PR DESCRIPTION
# 오늘 한 일
### 1. dm방 만드는 것을 소켓으로 구현
- dm방은 채널이 없는 상태에서 방을 만들기 때문에 방 만들기 과정과 유저 추가 과정이 동시에 이루어져야 한다.
- 내가 b를 dm방에 초대했다면 b는 초대 받은 dm방 목록을 자신의 dm리스트에서 확인할 수 있다.

### 2. 추후에 사용할 채널 검색 쿼리 작성