### PR TITLE
Popover 커스텀 완료

### DIFF
--- a/client/src/components/ChannelListBox/ChannelListBox.tsx
+++ b/client/src/components/ChannelListBox/ChannelListBox.tsx
@@ -5,6 +5,7 @@ import ChannelListHeader from './ChannelListHeader/ChannelListHeader';
 
 const Container = styled.div`
   padding: ${(props) => props.theme.size.s} 0;
+  min-height: 200px;
 `;
 
 const ChannelListBox = ({ channelType }: { channelType: number }): ReactElement => {

--- a/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/ChannelListHeader.tsx
@@ -1,8 +1,8 @@
-import React, { useState, ReactElement } from 'react';
+import React, { useState, ReactElement, useRef } from 'react';
 import styled, { css } from 'styled-components';
 import { flex } from '@/styles/mixin';
 import { CHANNEL_TYPE } from '@/utils/constants';
-import { DimModal, MenuModal, ArrowDownIcon, PlusIcon, DotIcon } from '@/components';
+import { DimModal, ArrowDownIcon, PlusIcon, DotIcon, Popover } from '@/components';
 import {
   AddUsersModalHeader,
   AddUsersModalBody,
@@ -130,6 +130,8 @@ const ChannelListBox = ({
     setAddUsersModalVisible((state) => !state);
   };
 
+  const ref = useRef<HTMLDivElement>(null);
+
   return (
     <>
       {createChannelModalVisible && (
@@ -156,36 +158,6 @@ const ChannelListBox = ({
         />
       )}
       <Container onClick={toggleChannelList}>
-        {addChannelsModalVisible && (
-          <MenuModal
-            top="1.5rem"
-            right="-5rem"
-            visible={addChannelsModalVisible}
-            setVisible={setAddChannelsModalVisible}
-          >
-            <ModalListItem
-              onClick={
-                channelType === CHANNEL_TYPE.CHANNEL ? clickCreateChannelModal : clickAddUsersModal
-              }
-            >
-              {channelType === CHANNEL_TYPE.CHANNEL ? '채널 추가' : '대화 상대 추가'}
-            </ModalListItem>
-            <ModalListItem>{channelType === CHANNEL_TYPE.CHANNEL && '채널 검색'}</ModalListItem>
-          </MenuModal>
-        )}
-        {sectionOptionsModalVisible && (
-          <MenuModal
-            top="1.5rem"
-            right="-3.5rem"
-            visible={sectionOptionsModalVisible}
-            setVisible={setSectionOptionsModalVisible}
-          >
-            <ModalListItem onClick={clickCreateChannelModal}>
-              {channelType === CHANNEL_TYPE.CHANNEL ? '채널 추가' : '대화 상대 추가'}
-            </ModalListItem>
-            <ModalListItem>{channelType === CHANNEL_TYPE.CHANNEL && '채널 검색'}</ModalListItem>
-          </MenuModal>
-        )}
         <SubWrapper>
           <ArrowIcon rotated={!channelListVisible}>
             <ArrowDownIcon />
@@ -198,13 +170,32 @@ const ChannelListBox = ({
               <DotIcon />
             </DotIconBox>
           </PopupBox>
-          <PopupBox onClick={toggleAddChannelsModal}>
+          <PopupBox onClick={toggleAddChannelsModal} ref={ref}>
             <PlusIconBox>
               <PlusIcon size="22.5px" />
             </PlusIconBox>
           </PopupBox>
         </Controls>
       </Container>
+      {addChannelsModalVisible && ref.current && (
+        <Popover
+          anchorEl={ref.current}
+          offset={{ top: 0, left: 5 }}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+          visible={addChannelsModalVisible}
+          setVisible={setAddChannelsModalVisible}
+        >
+          <ModalListItem
+            onClick={
+              channelType === CHANNEL_TYPE.CHANNEL ? clickCreateChannelModal : clickAddUsersModal
+            }
+          >
+            {channelType === CHANNEL_TYPE.CHANNEL ? '채널 추가' : '대화 상대 추가'}
+          </ModalListItem>
+          <ModalListItem>{channelType === CHANNEL_TYPE.CHANNEL && '채널 검색'}</ModalListItem>
+        </Popover>
+      )}
     </>
   );
 };

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { getUserRequest } from '@/store/modules/user.slice';
 import { flex } from '@/styles/mixin';
 import { useAuthState, useUserState } from '@/hooks';
 import { logoutRequest } from '@/store/modules/auth.slice';
-import { DimModal, UserStateIcon, MenuModal, ClockIcon } from '@/components';
+import { DimModal, UserStateIcon, ClockIcon, Popover } from '@/components';
 import theme from '@/styles/theme';
 import { UserProfileModalHeader, UserProfileModalBody } from './UserProfileBox';
 
@@ -80,7 +80,7 @@ const ModalListItem = styled.div`
 `;
 
 const ModalUserProfileBox = styled.div`
-  width: 100%;
+  width: 300px;
   padding: 0.8rem 1.2rem 1.5rem 1.2rem;
   ${flex('center', 'flex-start')};
 `;
@@ -146,6 +146,8 @@ const Header: React.FC = () => {
 
   const workspaceName = '부스트캠프 2020 멤버십';
 
+  const ref = useRef<HTMLDivElement>(null);
+
   return (
     <Container>
       <Title>
@@ -162,10 +164,12 @@ const Header: React.FC = () => {
           setVisible={setEditProfileVisible}
         />
       )}
-      {menuModalVisible && (
-        <MenuModal
-          top="2.5rem"
-          right="1rem"
+      {menuModalVisible && ref.current && (
+        <Popover
+          anchorEl={ref.current}
+          offset={{ top: 5, left: 0 }}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
           visible={menuModalVisible}
           setVisible={setMenuModalVisible}
         >
@@ -184,9 +188,9 @@ const Header: React.FC = () => {
           <ModalListItem>View profile</ModalListItem>
           <Line />
           <Logout onClick={handleLogout}>Sign out of {workspaceName}</Logout>
-        </MenuModal>
+        </Popover>
       )}
-      <ProfileBox onMouseDown={toggleMenuModal}>
+      <ProfileBox onMouseDown={toggleMenuModal} ref={ref}>
         <ProfileBackground />
         <ProfileImg src={userInfo?.image} />
         <Icon>

--- a/client/src/components/common/Popover/Popover.tsx
+++ b/client/src/components/common/Popover/Popover.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useRef, PropsWithChildren, ReactNode } from 'react';
+import styled, { css } from 'styled-components';
+import { flex, modalBoxShadow } from '@/styles/mixin';
+import { useOnClickOutside } from '@/hooks';
+
+const TopLayer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: unset;
+  z-index: 15;
+`;
+
+interface ContainerProps {
+  width?: string;
+  backgroundColor?: string;
+  top: string;
+  left: string;
+  trans: {
+    y: number;
+    x: number;
+  };
+}
+
+const Container = styled.div<ContainerProps>`
+  position: absolute;
+  ${(props) =>
+    props.top &&
+    css`
+      top: ${props.top};
+    `}
+  ${(props) =>
+    props.left &&
+    css`
+      left: ${props.left};
+    `}
+  ${(props) => `transform: translate(${props.trans.x}%, ${props.trans.y}%);`}
+  width: ${(props) => props.width ?? 'auto'};
+  min-width: 13rem;
+  height: auto;
+  background-color: ${(props) => props.backgroundColor ?? props.theme.color.modalWhite};
+  border-radius: 5px;
+  padding: 0.8rem 0;
+  outline: 0;
+  ${modalBoxShadow}
+  ${flex('center', 'center', 'column')}
+  z-index: 10;
+`;
+
+interface AnchorOrigin {
+  vertical: 'top' | 'center' | 'bottom';
+  horizontal: 'left' | 'center' | 'right';
+}
+
+interface TransformOrigin {
+  vertical: 'top' | 'center' | 'bottom';
+  horizontal: 'left' | 'center' | 'right';
+}
+
+interface Offset {
+  top?: number;
+  left?: number;
+}
+
+interface PopoverProps {
+  anchorEl: HTMLElement;
+  width?: string;
+  anchorOrigin?: AnchorOrigin;
+  transformOrigin?: TransformOrigin;
+  offset: Offset;
+  backgroundColor?: string;
+  visible: boolean;
+  setVisible: (a: any) => void;
+}
+
+const Popover: React.FC<PropsWithChildren<PopoverProps>> = ({
+  anchorEl,
+  anchorOrigin,
+  transformOrigin,
+  width,
+  offset,
+  backgroundColor,
+  visible,
+  setVisible,
+  children,
+}: PropsWithChildren<PopoverProps>) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(containerRef, () => setVisible(false));
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    if (e.target === containerRef.current) {
+      return;
+    }
+    setVisible(false);
+  };
+
+  const parentBox = anchorEl.getBoundingClientRect();
+
+  let top = 0;
+  let left = 0;
+
+  if (anchorOrigin) {
+    const { vertical, horizontal } = anchorOrigin;
+    if (vertical === 'top') {
+      top = parentBox.top;
+    } else if (vertical === 'center') {
+      top = parentBox.top + parentBox.height / 2;
+    } else if (vertical === 'bottom') {
+      top = parentBox.bottom;
+    }
+
+    if (horizontal === 'left') {
+      left = parentBox.left;
+    } else if (horizontal === 'center') {
+      left = parentBox.left + parentBox.width / 2;
+    } else if (horizontal === 'right') {
+      left = parentBox.right;
+    }
+  }
+
+  if (offset?.top) {
+    top += offset.top;
+  }
+  if (offset?.left) {
+    left += offset.left;
+  }
+
+  let x = 0;
+  let y = 0;
+
+  if (transformOrigin) {
+    const { vertical, horizontal } = transformOrigin;
+    if (vertical === 'top') {
+      y = 0;
+    } else if (vertical === 'center') {
+      y = -50;
+    } else if (vertical === 'bottom') {
+      y = -100;
+    }
+
+    if (horizontal === 'left') {
+      x = 0;
+    } else if (horizontal === 'center') {
+      x = -50;
+    } else if (horizontal === 'right') {
+      x = -100;
+    }
+  }
+
+  return visible ? (
+    <TopLayer>
+      <Container
+        width={width}
+        top={`${top}px`}
+        left={`${left}px`}
+        ref={containerRef}
+        trans={{ x, y }}
+        backgroundColor={backgroundColor}
+        onClick={handleClick}
+      >
+        {children}
+      </Container>
+    </TopLayer>
+  ) : null;
+};
+
+Popover.defaultProps = {
+  anchorOrigin: {
+    vertical: 'top',
+    horizontal: 'left',
+  },
+  transformOrigin: {
+    vertical: 'top',
+    horizontal: 'left',
+  },
+};
+
+export default Popover;

--- a/client/src/components/common/ThreadItem/ThreadItem.tsx
+++ b/client/src/components/common/ThreadItem/ThreadItem.tsx
@@ -30,11 +30,14 @@ const Container = styled.div`
 `;
 
 const Popup = styled.div`
-  display: flex;
+  display: none;
   position: absolute;
   right: 1rem;
   /* top: -0.75rem; */ // modal 추상화 전까지 잠시 주석처리함
   border-radius: 5px;
+  ${Container}:hover & {
+    display: flex;
+  }
 `;
 
 const UserImgBox = styled.div``;
@@ -110,18 +113,8 @@ const ThreadItem: React.FC<ThreadItemProps> = ({
 }: ThreadItemProps) => {
   const isSameUser = prevThreadUserId === thread.userId;
 
-  const [popupVisible, setPopupVisible] = useState(false);
-
-  const handleMouseEnter = () => {
-    setPopupVisible(true);
-  };
-
-  const handleMouseLeave = () => {
-    setPopupVisible(false);
-  };
-
   return (
-    <Container onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+    <Container>
       <UserImgBox>
         <UserImg src={thread.image} />
       </UserImgBox>
@@ -134,14 +127,9 @@ const ThreadItem: React.FC<ThreadItemProps> = ({
         {thread.subCount > 0 && !isParentThreadOfRightSideBar && <ReplyButton thread={thread} />}
         <EmojiBox thread={thread} />
       </ContentBox>
-      {popupVisible && (
-        <Popup>
-          <ThreadPopup
-            thread={thread}
-            isParentThreadOfRightSideBar={isParentThreadOfRightSideBar}
-          />
-        </Popup>
-      )}
+      <Popup>
+        <ThreadPopup thread={thread} isParentThreadOfRightSideBar={isParentThreadOfRightSideBar} />
+      </Popup>
     </Container>
   );
 };

--- a/client/src/components/common/ThreadItem/ThreadPopup/ThreadPopup.tsx
+++ b/client/src/components/common/ThreadItem/ThreadPopup/ThreadPopup.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Thread } from '@/types';
 import { Link } from 'react-router-dom';
-import { DimModal, MenuModal, ReactionIcon, CommentIcon, DotIcon } from '@/components';
+import { Popover, MenuModal, ReactionIcon, CommentIcon, DotIcon } from '@/components';
 import { flex, hoverActive } from '@/styles/mixin';
 import theme from '@/styles/theme';
 
@@ -68,6 +68,8 @@ const ThreadPopup: React.FC<ThreadPopupProps> = ({
     console.log('click');
   };
 
+  const popoverRef = useRef<HTMLDivElement>(null);
+
   return (
     <Container>
       <ReactionBox>
@@ -80,23 +82,25 @@ const ThreadPopup: React.FC<ThreadPopupProps> = ({
           </CommentBox>
         </Link>
       )}
-      <MoreActionBox onClick={openMenuModal}>
+      <MoreActionBox onClick={openMenuModal} ref={popoverRef}>
         <DotIcon color={theme.color.black5} />
-        {menuModalVisible && (
-          <MenuModal
-            top="1rem"
-            right="1rem"
-            visible={menuModalVisible}
-            setVisible={setMenuModalVisible}
-          >
-            <ModalListItem onClick={openEditModal}>Unfollow message</ModalListItem>
-            <ModalListItem>Copy link</ModalListItem>
-            <ModalListItem>Pin to this conversation</ModalListItem>
-            <ModalListItem>Edit message</ModalListItem>
-            <ModalListItem>Delete message</ModalListItem>
-          </MenuModal>
-        )}
       </MoreActionBox>
+      {menuModalVisible && popoverRef.current && (
+        <Popover
+          anchorEl={popoverRef.current}
+          offset={{ top: 0, left: 5 }}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'center', horizontal: 'right' }}
+          visible={menuModalVisible}
+          setVisible={setMenuModalVisible}
+        >
+          <ModalListItem onClick={openEditModal}>Unfollow message</ModalListItem>
+          <ModalListItem>Copy link</ModalListItem>
+          <ModalListItem>Pin to this conversation</ModalListItem>
+          <ModalListItem>Edit message</ModalListItem>
+          <ModalListItem>Delete message</ModalListItem>
+        </Popover>
+      )}
     </Container>
   );
 };

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -6,3 +6,4 @@ export { default as DimModal } from './DimModal/DimModal';
 export { default as ModalCloseBox } from './ModalCloseBox/ModalCloseBox';
 export { default as MenuModal } from './MenuModal/MenuModal';
 export { default as ThreadInputBox } from './ThreadInputBox/ThreadInputBox';
+export { default as Popover } from './Popover/Popover';


### PR DESCRIPTION
## 구현 내용

![12 10 구현](https://user-images.githubusercontent.com/61396464/101666215-465b7580-3a91-11eb-9eaf-8dbf1f3b91da.gif)

### 1. 리팩토링
- 설명을 생략하겠습니다..

### 2. 커스텀 Popover 구현
- 기존의 MenuModal은 너무 구려서 제대로 모달을 만들어봤습니다.

- MenuModal 같이 dim 영역 없는애를 Popover라고 부르길래 그렇게 네이밍 했습니다.

- 이제 **부모 요소 밑에 둘 필요가 없어요!** 
원하는 곳에 두면 타겟 엘리먼트의 포지션으로 알아서 찾아가는 방식 👍

### 3. 헤더, 스레드 아이템 팝업, 채널 리스트 팝업에 Popover 적용
- 제가 적용한 코드 보면서 비슷하게 쓰시면 됩니다.

- 사용법은 아래 링크에서 보시면서 속성값으로 top, left, anchorEl, anchorOrigin, transformOrigin 을 적절하게 주시면 됩니다.

- 동작이 정말 마음에 드네요 👏

https://material-ui.com/components/popover/

링크 타고가서 스크롤 살짝 내리면 아래 화면 나오는데 몇 번 클릭해보면 바로 이해하실거에요.

---

![image](https://user-images.githubusercontent.com/61396464/101665689-a69de780-3a90-11eb-960e-6c27968d5782.png)
