### PR TITLE
실시간 이모지 subThread에서도 동작되도록 수정 / 불필요한 코드 제거 (popover)

### DIFF
--- a/client/src/components/common/EmojiListModal/EmojiListModal.tsx
+++ b/client/src/components/common/EmojiListModal/EmojiListModal.tsx
@@ -15,6 +15,7 @@ const Emoji = styled.img`
   width: 22px;
   height: 22px;
   user-select: none;
+  cursor: pointer;
 `;
 
 interface EmojiListModalProps {

--- a/client/src/components/common/Popover/Popover.tsx
+++ b/client/src/components/common/Popover/Popover.tsx
@@ -91,7 +91,6 @@ const Popover: React.FC<PropsWithChildren<PopoverProps>> = ({
   useOnClickOutside(containerRef, () => setVisible(false));
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
     if (e.target === containerRef.current) {
       return;
     }

--- a/client/src/components/common/ThreadItem/EmojiBox/EmojiBoxItem/EmojiBoxItem.tsx
+++ b/client/src/components/common/ThreadItem/EmojiBox/EmojiBoxItem/EmojiBoxItem.tsx
@@ -116,7 +116,6 @@ const EmojiBoxItem: React.FC<EmojiBoxItemProps> = ({ emoji, thread }: EmojiBoxIt
           alt="emoji url"
           width="36px"
           height="36px"
-          draggable="false"
         />
         <ToolTipDescribe>
           {getUserListNameInEmoji(emoji)}
@@ -130,7 +129,6 @@ const EmojiBoxItem: React.FC<EmojiBoxItemProps> = ({ emoji, thread }: EmojiBoxIt
           alt="emoji url"
           width="16px"
           height="16px"
-          draggable="false"
         />
         {emoji.userList && <span key={`${emoji.id}length`}>{emoji.userList.length}</span>}
       </EmojiItem>

--- a/client/src/store/modules/subThread.slice.ts
+++ b/client/src/store/modules/subThread.slice.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Thread, initialThread } from '@/types';
+import { Thread, initialThread, EmojiOfThread } from '@/types';
 
 interface SubThreadBox {
   parentThread: Thread;
@@ -36,6 +36,21 @@ const subThreadSlice = createSlice({
       }
       state.parentThread.subCount += 1;
     },
+    changeEmojiOfSubThread(
+      state,
+      { payload }: PayloadAction<{ emoji: EmojiOfThread[]; threadId: number }>,
+    ) {
+      if (state.parentThread.id === payload.threadId) {
+        state.parentThread.emoji = payload.emoji;
+      } else {
+        const targetThread = state.subThreadList?.find(
+          (thread) => Number(thread.id) === Number(payload.threadId),
+        );
+        if (targetThread) {
+          targetThread.emoji = payload.emoji;
+        }
+      }
+    },
   },
 });
 
@@ -45,6 +60,7 @@ export const {
   getSubThreadSuccess,
   getSubThreadFailure,
   addSubThread,
+  changeEmojiOfSubThread,
 } = subThreadSlice.actions; // action 나눠서 export 하기
 
 export default subThreadSlice.reducer;

--- a/client/src/store/modules/subThread.slice.ts
+++ b/client/src/store/modules/subThread.slice.ts
@@ -29,12 +29,12 @@ const subThreadSlice = createSlice({
     },
     getSubThreadFailure(state, action) {},
     addSubThread(state, action) {
+      state.parentThread.subCount += 1;
       if (state.subThreadList?.length) {
         state.subThreadList.push(action.payload.thread);
-      } else {
-        state.subThreadList = [action.payload.thread];
+        return;
       }
-      state.parentThread.subCount += 1;
+      state.subThreadList = [action.payload.thread];
     },
     changeEmojiOfSubThread(
       state,
@@ -42,13 +42,13 @@ const subThreadSlice = createSlice({
     ) {
       if (state.parentThread.id === payload.threadId) {
         state.parentThread.emoji = payload.emoji;
-      } else {
-        const targetThread = state.subThreadList?.find(
-          (thread) => Number(thread.id) === Number(payload.threadId),
-        );
-        if (targetThread) {
-          targetThread.emoji = payload.emoji;
-        }
+        return;
+      }
+      const targetThread = state.subThreadList?.find(
+        (thread) => Number(thread.id) === Number(payload.threadId),
+      );
+      if (targetThread) {
+        targetThread.emoji = payload.emoji;
       }
     },
   },

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Thread, ThreadResponse } from '@/types';
+import { EmojiOfThread, Thread, ThreadResponse } from '@/types';
 
 interface ThreadState {
   threadList: Thread[] | null;
@@ -22,11 +22,6 @@ export interface createThreadRequestPayload {
   channelId: number;
   content: string;
   parentId: number | null;
-}
-
-interface EmojiOfThread {
-  id: number;
-  userList: number[];
 }
 
 // 리듀서
@@ -77,7 +72,10 @@ const threadSlice = createSlice({
     setScrollable(state, { payload }: PayloadAction<{ canScroll: boolean }>) {
       state.canScroll = payload.canScroll;
     },
-    changeEmoji(state, { payload }: PayloadAction<{ emoji: EmojiOfThread[]; threadId: number }>) {
+    changeEmojiOfThread(
+      state,
+      { payload }: PayloadAction<{ emoji: EmojiOfThread[]; threadId: number }>,
+    ) {
       const targetThread = state.threadList?.find(
         (thread) => Number(thread.id) === Number(payload.threadId),
       );
@@ -98,7 +96,7 @@ export const {
   createThreadFailure,
   addThread,
   setScrollable,
-  changeEmoji,
+  changeEmojiOfThread,
   updateSubThreadInfo,
 } = threadSlice.actions; // action 나눠서 export 하기
 

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -8,9 +8,9 @@ import {
   enterRoomRequest,
   leaveRoomRequest,
 } from '@/store/modules/socket.slice';
-import { addThread, changeEmoji, updateSubThreadInfo } from '@/store/modules/thread.slice';
+import { addThread, changeEmojiOfThread, updateSubThreadInfo } from '@/store/modules/thread.slice';
+import { changeEmojiOfSubThread, addSubThread } from '@/store/modules/subThread.slice';
 
-import { addSubThread } from '@/store/modules/subThread.slice';
 import {
   updateChannelUnread,
   updateChannelTopic,
@@ -64,7 +64,8 @@ function subscribeSocket(socket: Socket) {
       if (isEmojiEvent(data)) {
         const { room, emoji, threadId, type } = data;
         if (emoji && threadId) {
-          emit(changeEmoji({ emoji, threadId }));
+          emit(changeEmojiOfThread({ emoji, threadId }));
+          emit(changeEmojiOfSubThread({ emoji, threadId }));
         }
         return;
       }


### PR DESCRIPTION
1. 실시간 이모지 subThread에서도 동작되도록 수정 
- subthread 리듀서로 보내, parent thread와 subthreadList를 확인하고 처리해주었습니다.

2. 불필요한 코드 제거 (popover)
- 멘토님이 언급해주셨던 `e.stopPropagation();` 을 삭제했습니다.