### PR TITLE
우측 사이드바 공통 컴포넌트 구현 및 디테일/서브스레드 주입

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,7 +24,7 @@ const App = () => {
           <Route path="/verify" component={EmailVerifyPage} />
           <Route path="/signup" component={SignupPage} />
           <Route
-            path="/client/1/:channelId(\d+)?/:rightSideType?/:threadId(\d+)?"
+            path="/client/1/:channelId(\d+)?/:rightSideType(detail|user_profile|thread)?/:threadId(\d+)?"
             exact
             component={withAuth(WorkSpacePage)}
           />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/pages';
 import theme from '@/styles/theme';
 import { GlobalStyle } from '@/styles';
+import { withAuth } from '@/hoc';
 
 const App = () => {
   return (
@@ -18,14 +19,14 @@ const App = () => {
       <GlobalStyle />
       <BrowserRouter>
         <Switch>
-          <Route path="/" exact component={HomePage} />
+          <Route path="/" exact component={withAuth(HomePage)} />
           <Route path="/login" component={LoginPage} />
           <Route path="/verify" component={EmailVerifyPage} />
           <Route path="/signup" component={SignupPage} />
           <Route
             path="/client/1/:channelId(\d+)?/:rightSideType?/:threadId(\d+)?"
             exact
-            component={WorkSpacePage}
+            component={withAuth(WorkSpacePage)}
           />
           <Redirect to="/" />
         </Switch>

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -57,6 +57,9 @@ instance.interceptors.response.use(
     if (axios.isCancel(err)) {
       console.log('요청 취소', err);
     } else {
+      if (err.response.status === 401) {
+        window.location.href = '/login';
+      }
       console.error('api 에러', err);
     }
     return Promise.reject(err);

--- a/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/CreateChannelModal/CreateChannelModalBody/CreateChannelModalBody.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { useAuthState, useChannelState, useUserState } from '@/hooks';
 import { createChannelRequest } from '@/store/modules/channel.slice';
 import { useDispatch } from 'react-redux';
+import { PoundIcon, LockIcon } from '@/components';
+import theme from '@/styles/theme';
 
 interface Props {
   secret?: boolean;
@@ -55,9 +57,8 @@ const DescriptionInput = styled.input`
 
 const InputBox = styled.div<Props>`
   position: relative;
-  &::before {
+  .icon {
     position: absolute;
-    content: ${(props) => (props.secret ? 'O' : '#')};
     top: 15px;
     left: 10px;
     color: ${(props) => props.theme.color.gray2};
@@ -152,6 +153,8 @@ const CreateButton = styled.button<Props>`
       `}
 `;
 
+const IconBox = styled.div``;
+
 interface CreateChannelModalBodyProps {
   setCreateChannelModalVisible: (fn: (state: boolean) => boolean) => void;
   setSecret: (fn: (state: boolean) => boolean) => void;
@@ -209,7 +212,14 @@ const CreateChannelModalBody: React.FC<CreateChannelModalBodyProps> = ({
             <LabelContent>Name</LabelContent>
             {name === '' && <NameAlert>Don't forget to name your channel.</NameAlert>}
           </LabelBox>
-          <InputBox secret={secret}>
+          <InputBox>
+            <IconBox className="icon">
+              {secret ? (
+                <LockIcon size="12px" color={theme.color.black6} />
+              ) : (
+                <PoundIcon size="12px" color={theme.color.black6} />
+              )}
+            </IconBox>
             <NameInput onChange={changeName} value={name} required placeholder="e.g. plan-budget" />
           </InputBox>
         </Label>

--- a/client/src/components/DetailBox/DeatailHeader/DetailHeader.tsx
+++ b/client/src/components/DetailBox/DeatailHeader/DetailHeader.tsx
@@ -1,48 +1,54 @@
 import React from 'react';
-import { useChannelState } from '@/hooks';
-import { useDispatch } from 'react-redux';
-import { flex } from '@/styles/mixin';
 import styled from 'styled-components';
+import { useChannelState } from '@/hooks';
+import { flex } from '@/styles/mixin';
+import { LockIcon, PoundIcon } from '@/components';
+import theme from '@/styles/theme';
 
 const Container = styled.div`
-  border: 1px solid red;
-  width: 100%;
   ${flex('center', 'space-between')}
-`;
-const Left = styled.div`
-  padding: ${(props) => props.theme.size.m};
-`;
-
-const Title = styled.div`
-  font-size: 20px;
+  width: 100%;
+  height: 4.3rem;
+  flex-shrink: 0;
+  background-color: white;
 `;
 
-const Content = styled.div`
-  font-size: 12px;
+const LeftBox = styled.div``;
+
+const LeftTopBox = styled.div`
+  font-weight: 800;
 `;
 
-const Button = styled.button`
-  font-size: 25px;
-  background: none;
-  border: none;
-  padding: ${(props) => props.theme.size.m};
+const LeftBottomBox = styled.div`
+  width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const ChannelTitle = styled.span`
+  color: ${(props) => props.theme.color.black5};
+  font-size: 0.8rem;
+  font-weight: 200;
+  margin-left: 0.2rem;
 `;
 
 const DetailHeader: React.FC = () => {
   const { current } = useChannelState();
-  const dispatch = useDispatch();
-  const onClick = () => {
-    // Link로 연결하는 작업
-  };
+
   return (
     <Container>
-      <Left>
-        <Title>Details</Title>
-        <Content>
-          {current?.isPublic} {current?.name}
-        </Content>
-      </Left>
-      <Button onClick={onClick}>X</Button>
+      <LeftBox>
+        <LeftTopBox>Detail</LeftTopBox>
+        <LeftBottomBox>
+          {current?.isPublic ? (
+            <PoundIcon size="10px" color={theme.color.black5} />
+          ) : (
+            <LockIcon size="10px" color={theme.color.black5} />
+          )}
+          <ChannelTitle>{current?.name}</ChannelTitle>
+        </LeftBottomBox>
+      </LeftBox>
     </Container>
   );
 };

--- a/client/src/components/DetailBox/DetailBody/DetailButtonBox/DetailButtonBox.tsx
+++ b/client/src/components/DetailBox/DetailBody/DetailButtonBox/DetailButtonBox.tsx
@@ -3,13 +3,16 @@ import styled from 'styled-components';
 import { flex } from '@/styles/mixin';
 
 const Container = styled.div`
-  ${flex('center', 'space-between')}
-  padding: 10px 30px;
+  ${flex('center', 'space-around')}
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid ${(props) => props.theme.color.lightGray2};
 `;
 
 const Label = styled.label`
   ${flex('center', 'center', 'column')}
-  color: ${(props) => props.theme.color.gray1};
+  color: ${(props) => props.theme.color.black8};
+  font-size: 0.8rem;
+  font-weight: 200;
 `;
 
 const Button = styled.button`
@@ -17,7 +20,15 @@ const Button = styled.button`
   border-radius: 50%;
   width: 40px;
   height: 40px;
-  background: ${(props) => props.theme.color.gray3};
+  border: none;
+  outline: none;
+  background-color: #f3f3f3;
+  &:hover {
+    background-color: ${(props) => props.theme.color.lightGray2};
+  }
+  &:active {
+    background-color: ${(props) => props.theme.color.lightGray1};
+  }
 `;
 
 export const DetailButtonBox: React.FC = () => {

--- a/client/src/components/DetailBox/DetailBody/DetailList/DetailList.tsx
+++ b/client/src/components/DetailBox/DetailBody/DetailList/DetailList.tsx
@@ -1,30 +1,58 @@
 /* eslint-disable no-shadow */
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useChannelState } from '@/hooks';
 import { flex } from '@/styles/mixin';
 import { JoinedUser } from '@/types';
+import { RightIcon, RightArrowLineIcon } from '@/components';
+import theme from '@/styles/theme';
 
-const Container = styled.div`
-  padding: ${(props) => props.theme.size.m};
-`;
+const Container = styled.div``;
 
 const ListItem = styled.div`
   ${flex('center', 'space-between')}
+  cursor: pointer;
 `;
 
 const ListItemName = styled.div`
   color: ${(props) => props.theme.color.black3};
-  font-size: ${(props) => props.theme.size.m};
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: ${(props) => props.theme.color.lightBlack};
 `;
 
-const Arrow = styled.div`
-  color: ${(props) => props.theme.color.gray3};
+interface ArrowProps {
+  rotated: boolean;
+}
+
+const ArrowIcon = styled.div<ArrowProps>`
+  ${flex()}
+  width: 2rem;
+  height: 2rem;
+  margin: 0 0.4rem;
+  color: ${(props) => props.theme.color.white};
   font-size: ${(props) => props.theme.size.m};
+  background: transparent;
+  border: none;
+  border-radius: 5px;
+  transition: 0.3s;
+  ${(props) =>
+    props.rotated &&
+    css`
+      transform: rotate(90deg);
+      transition: 0.3s;
+    `}
+  &:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+  outline: 0;
+  cursor: pointer;
 `;
 
 const ItemBox = styled.div`
-  margin-top: 20px;
+  width: 100%;
+  padding: 0.8rem 0.9rem;
+  border-bottom: 1px solid ${(props) => props.theme.color.lightGray2};
 `;
 
 const MemberItem = styled.div`
@@ -45,9 +73,6 @@ const MemberInfo = styled.div`
 export const DetailList: React.FC = () => {
   const [about, setAbout] = useState(false);
   const [members, setMembers] = useState(false);
-  const [organization, setOrganization] = useState(false);
-  const [pinned, setPinned] = useState(false);
-  const [files, setFiles] = useState(false);
   const { users } = useChannelState();
 
   const openAbout = () => {
@@ -58,30 +83,22 @@ export const DetailList: React.FC = () => {
     setMembers((members) => !members);
   };
 
-  const openOrganizations = () => {
-    setOrganization((organization) => !organization);
-  };
-
-  const openPinned = () => {
-    setPinned((pinned) => !pinned);
-  };
-
-  const openFiles = () => {
-    setFiles((files) => !files);
-  };
-
   return (
     <Container>
       <ItemBox>
         <ListItem onClick={openAbout}>
           <ListItemName>About</ListItemName>
-          <Arrow>{about ? '∨' : '＞'}</Arrow>
+          <ArrowIcon rotated={about}>
+            <RightArrowLineIcon size="14px" color={theme.color.black5} />
+          </ArrowIcon>
         </ListItem>
       </ItemBox>
       <ItemBox onClick={openMembers}>
         <ListItem>
           <ListItemName>Members</ListItemName>
-          <Arrow>{members ? '∨' : '＞'}</Arrow>
+          <ArrowIcon rotated={members}>
+            <RightArrowLineIcon size="14px" color={theme.color.black5} />
+          </ArrowIcon>
         </ListItem>
         {members &&
           users?.map((user: JoinedUser) => (
@@ -90,24 +107,6 @@ export const DetailList: React.FC = () => {
               <MemberInfo>{user.displayName}</MemberInfo>
             </MemberItem>
           ))}
-      </ItemBox>
-      <ItemBox>
-        <ListItem onClick={openOrganizations}>
-          <ListItemName>Organizations</ListItemName>
-          <Arrow>{organization ? '∨' : '＞'}</Arrow>
-        </ListItem>
-      </ItemBox>
-      <ItemBox>
-        <ListItem onClick={openPinned}>
-          <ListItemName>Pinned</ListItemName>
-          <Arrow>{pinned ? '∨' : '＞'}</Arrow>
-        </ListItem>
-      </ItemBox>
-      <ItemBox>
-        <ListItem onClick={openFiles}>
-          <ListItemName>Files</ListItemName>
-          <Arrow>{files ? '∨' : '＞'}</Arrow>
-        </ListItem>
       </ItemBox>
     </Container>
   );

--- a/client/src/components/SubThreadListBox/SubThreadListBox.tsx
+++ b/client/src/components/SubThreadListBox/SubThreadListBox.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useSubThreadState } from '@/hooks';
-import { Redirect, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { getSubThreadRequest } from '@/store/modules/subThread.slice';
 import { isNumberTypeValue } from '@/utils/utils';
@@ -10,7 +10,6 @@ import { INPUT_BOX_TYPE } from '@/utils/constants';
 import ParentThread from './ParentThread/ParentThread';
 import SubThreadList from './SubThreadList/SubThreadList';
 import ReplyCountHorizon from './ReplyCountHorizon/ReplyCountHorizon';
-import SubThreadListHeader from './SubThreadListHeader/SubThreadListHeader';
 
 const Container = styled.div`
   width: 25rem;
@@ -23,7 +22,7 @@ const ListContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow-y: auto;
+  /* overflow-y: auto; */
 `;
 
 interface RightSideParams {
@@ -34,7 +33,7 @@ interface RightSideParams {
 
 const SubThreadListBox: React.FC = () => {
   const dispatch = useDispatch();
-  const { channelId, threadId }: RightSideParams = useParams();
+  const { threadId }: RightSideParams = useParams();
   const { parentThread, subThreadList } = useSubThreadState();
 
   useEffect(() => {
@@ -47,7 +46,6 @@ const SubThreadListBox: React.FC = () => {
     <>
       {isNumberTypeValue(threadId) && parentThread !== undefined && (
         <Container>
-          <SubThreadListHeader />
           <ListContainer>
             <ParentThread parentThread={parentThread} />
             {parentThread.subCount > 0 && <ReplyCountHorizon subCount={parentThread.subCount} />}

--- a/client/src/components/SubThreadListBox/SubThreadListHeader/SubThreadListHeader.tsx
+++ b/client/src/components/SubThreadListBox/SubThreadListHeader/SubThreadListHeader.tsx
@@ -69,9 +69,9 @@ const SubThreadListHeader = () => {
         <LeftTopBox>Thread</LeftTopBox>
         <LeftBottomBox>
           {current?.isPublic ? (
-            <PoundIcon size="11px" color={theme.color.lightBlack} />
+            <PoundIcon size="10px" color={theme.color.black5} />
           ) : (
-            <LockIcon size="11px" color={theme.color.lightBlack} />
+            <LockIcon size="10px" color={theme.color.black5} />
           )}
           <ChannelTitle>{current?.name}</ChannelTitle>
         </LeftBottomBox>

--- a/client/src/components/SubThreadListBox/SubThreadListHeader/SubThreadListHeader.tsx
+++ b/client/src/components/SubThreadListBox/SubThreadListHeader/SubThreadListHeader.tsx
@@ -14,8 +14,6 @@ const Container = styled.div`
   width: 100%;
   height: 4.3rem;
   flex-shrink: 0;
-  padding: 0 1.3rem;
-  border-bottom: 1px solid ${(props) => props.theme.color.lightGray2};
   background-color: white;
 `;
 

--- a/client/src/components/common/CloseIconBox/CloseIconBox.tsx
+++ b/client/src/components/common/CloseIconBox/CloseIconBox.tsx
@@ -1,0 +1,46 @@
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 5px;
+  cursor: pointer;
+  &:hover,
+  &:active {
+    background-color: ${(props) => props.theme.color.gray5};
+    path {
+      fill: ${(props) => props.theme.color.black4};
+    }
+  }
+  &:active {
+    background-color: ${(props) => props.theme.color.gray4};
+  }
+`;
+
+const Icon = styled.svg`
+  width: 12px;
+  height: 12px;
+`;
+
+const Path = styled.path`
+  fill: ${(props) => props.color ?? props.theme.color.black8};
+`;
+
+const CloseIconBox: React.FC = ({ color }: PropsWithChildren<{ color?: string }>) => {
+  return (
+    <Container>
+      <Icon version="1.1" x="0px" y="0px" viewBox="0 0 400 400">
+        <Path
+          color={color}
+          d="M235.375,200.004L392.671,42.709c9.772-9.764,9.772-25.607,0-35.371c-9.772-9.772-25.599-9.772-35.372,0  L200.004,164.633L42.701,7.338c-9.772-9.772-25.599-9.772-35.371,0c-9.773,9.764-9.773,25.607,0,35.371l157.303,157.295  L7.33,357.299c-9.773,9.765-9.773,25.607,0,35.371c4.886,4.879,11.29,7.321,17.686,7.321s12.799-2.442,17.686-7.329l157.304-157.295  l157.294,157.295c4.887,4.887,11.291,7.329,17.686,7.329c6.396,0,12.8-2.442,17.687-7.329c9.772-9.764,9.772-25.607,0-35.371  L235.375,200.004z"
+        />
+      </Icon>
+    </Container>
+  );
+};
+
+export default CloseIconBox;

--- a/client/src/components/common/Icon/RightArrowLineIcon/RightArrowLineIcon.tsx
+++ b/client/src/components/common/Icon/RightArrowLineIcon/RightArrowLineIcon.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+const Path = styled.path`
+  fill: ${(props) => props.color ?? props.theme.color.black5};
+`;
+
+const RightArrowLineIcon = ({
+  color,
+  size,
+}: PropsWithChildren<{ color?: string; size?: string }>) => {
+  return (
+    <svg width={size ?? '16px'} height={size ?? '16px'} viewBox="0 0 320 512">
+      <Path
+        color={color}
+        d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
+      />
+    </svg>
+  );
+};
+
+export default RightArrowLineIcon;

--- a/client/src/components/common/Icon/index.ts
+++ b/client/src/components/common/Icon/index.ts
@@ -13,3 +13,4 @@ export { default as ReactionIcon } from './ReactionIcon/ReactionIcon';
 export { default as CommentIcon } from './CommentIcon/CommentIcon';
 export { default as PaperPlaneIcon } from './PaperPlaneIcon/PaperPlaneIcon';
 export { default as RightIcon } from './RightIcon/RightIcon';
+export { default as RightArrowLineIcon } from './RightArrowLineIcon/RightArrowLineIcon';

--- a/client/src/components/common/RightSideBar/RightSideBar.tsx
+++ b/client/src/components/common/RightSideBar/RightSideBar.tsx
@@ -4,19 +4,22 @@ import RightSideBarHeader from './RightSideBarHeader/RightSideBarHeader';
 import RightSideBarBody from './RightSideBarBody/RightSideBarBody';
 
 const Container = styled.div`
-  background-color: orange;
+  width: 25rem;
+  display: flex;
+  flex-direction: column;
 `;
 
 interface RightSideBarProps {
-  type: string;
-  channelId: number;
+  url: string;
+  header: React.ReactNode;
+  body: React.ReactNode;
 }
 
-const RightSideBar: React.FC<RightSideBarProps> = ({ type, channelId }: RightSideBarProps) => {
+const RightSideBar: React.FC<RightSideBarProps> = ({ url, header, body }: RightSideBarProps) => {
   return (
     <Container>
-      <RightSideBarHeader title={type} channelId={channelId} channelName="channel name" />
-      <RightSideBarBody type={type} />
+      <RightSideBarHeader url={url}>{header}</RightSideBarHeader>
+      <RightSideBarBody>{body}</RightSideBarBody>
     </Container>
   );
 };

--- a/client/src/components/common/RightSideBar/RightSideBarBody/RightSideBarBody.tsx
+++ b/client/src/components/common/RightSideBar/RightSideBarBody/RightSideBarBody.tsx
@@ -1,22 +1,22 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
-import { DetailBody, SubThreadListBox } from '@/components';
 
-// const Container = styled.div`
-//   background-color: orange;
-// `;
+const Container = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: auto;
+`;
 
 interface RightSideBarBodyProps {
-  type: string;
+  children: React.ReactNode;
 }
 
-const RightSideBarBody: React.FC<RightSideBarBodyProps> = ({ type }: RightSideBarBodyProps) => {
-  return (
-    <>
-      {type === 'detail' && <DetailBody />}
-      {type === 'thread' && <SubThreadListBox />}
-    </>
-  );
+const RightSideBarBody: React.FC<PropsWithChildren<RightSideBarBodyProps>> = ({
+  children,
+}: PropsWithChildren<RightSideBarBodyProps>) => {
+  return <Container>{children}</Container>;
 };
 
 export default RightSideBarBody;

--- a/client/src/components/common/RightSideBar/RightSideBarHeader/RightSideBarHeader.tsx
+++ b/client/src/components/common/RightSideBar/RightSideBarHeader/RightSideBarHeader.tsx
@@ -1,34 +1,34 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { flex } from '@/styles/mixin';
 import { Link } from 'react-router-dom';
+import { CloseIconBox } from '@/components';
 
 const Container = styled.div`
-  background-color: orange;
-  ${flex('center', 'space-between')};
+  ${flex('center', 'space-between')}
+  width: 100%;
+  height: 4.3rem;
+  flex-shrink: 0;
+  padding: 0 1.3rem;
+  border-bottom: 1px solid ${(props) => props.theme.color.lightGray2};
+  background-color: white;
 `;
 
-const LeftSideBox = styled.div``;
-
+const LeftBox = styled.div``;
 interface RightSideBarHeaderProps {
-  title: string;
-  channelId: number;
-  channelName: string;
+  url: string;
+  children: React.ReactNode;
 }
 
-const RightSideBarHeader: React.FC<RightSideBarHeaderProps> = ({
-  title,
-  channelId,
-  channelName,
-}: RightSideBarHeaderProps) => {
+const RightSideBarHeader: React.FC<PropsWithChildren<RightSideBarHeaderProps>> = ({
+  url,
+  children,
+}: PropsWithChildren<RightSideBarHeaderProps>) => {
   return (
     <Container>
-      <LeftSideBox>
-        <div>{title}</div>
-        <div>{channelName}</div>
-      </LeftSideBox>
-      <Link to={`/client/1/${channelId}`}>
-        <button type="button">X</button>
+      <LeftBox>{children}</LeftBox>
+      <Link to={url}>
+        <CloseIconBox />
       </Link>
     </Container>
   );

--- a/client/src/components/common/ThreadItem/EmojiBox/EmojiBox.tsx
+++ b/client/src/components/common/ThreadItem/EmojiBox/EmojiBox.tsx
@@ -6,6 +6,7 @@ import EmojiBoxItem from './EmojiBoxItem/EmojiBoxItem';
 
 const Container = styled.div`
   ${flex('center', 'flex-start', 'row')};
+  margin: 0.4rem 0;
 `;
 
 interface EmojiBoxProps {

--- a/client/src/components/common/ThreadItem/EmojiBox/EmojiBox.tsx
+++ b/client/src/components/common/ThreadItem/EmojiBox/EmojiBox.tsx
@@ -5,7 +5,6 @@ import { flex } from '@/styles/mixin';
 import EmojiBoxItem from './EmojiBoxItem/EmojiBoxItem';
 
 const Container = styled.div`
-  background-color: pink;
   ${flex('center', 'flex-start', 'row')};
 `;
 

--- a/client/src/components/common/ThreadItem/EmojiBox/EmojiBoxItem/EmojiBoxItem.tsx
+++ b/client/src/components/common/ThreadItem/EmojiBox/EmojiBoxItem/EmojiBoxItem.tsx
@@ -10,10 +10,13 @@ import { JoinedUser } from '@/types';
 
 const Container = styled.div`
   background-color: ${(props) => props.color};
-  border: 1px solid #1d9bd1;
+  box-shadow: inset 0 0 0 1px rgba(29, 155, 209);
   ${flex('center', 'flex-start', 'row')};
   position: relative;
   cursor: pointer;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999em;
+  margin-right: 0.2rem;
 `;
 // EFEFEF
 

--- a/client/src/components/common/ThreadItem/ReplyButton/ReplyButton.tsx
+++ b/client/src/components/common/ThreadItem/ReplyButton/ReplyButton.tsx
@@ -12,7 +12,6 @@ import theme from '@/styles/theme';
 const ReplyBox = styled.div`
   ${flex('center', 'space-between')};
   width: 30rem;
-  margin-top: 0.4rem;
   padding: 0.2rem 0.4rem;
   border-radius: 5px;
   border: 1px solid transparent;

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -8,3 +8,4 @@ export { default as MenuModal } from './MenuModal/MenuModal';
 export { default as ThreadInputBox } from './ThreadInputBox/ThreadInputBox';
 export { default as EmojiListModal } from './EmojiListModal/EmojiListModal';
 export { default as Popover } from './Popover/Popover';
+export { default as CloseIconBox } from './CloseIconBox/CloseIconBox';

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -7,3 +7,4 @@ export { default as DetailHeader } from './DetailBox/DeatailHeader/DetailHeader'
 export { default as DetailBody } from './DetailBox/DetailBody/DetailBody';
 export { default as EmailBox } from './EmailBox/EmailBox';
 export { default as CodeVerifyBox } from './CodeVerifyBox/CodeVerifyBox';
+export { default as SubThreadListHeader } from './SubThreadListBox/SubThreadListHeader/SubThreadListHeader';

--- a/client/src/hoc/index.ts
+++ b/client/src/hoc/index.ts
@@ -1,1 +1,2 @@
 export { RestrictRoute } from './RestrictRoute';
+export { default as withAuth } from './withAuth';

--- a/client/src/hoc/withAuth.tsx
+++ b/client/src/hoc/withAuth.tsx
@@ -1,0 +1,16 @@
+import { useAuthState } from '@/hooks';
+import React, { FC } from 'react';
+import { Redirect } from 'react-router-dom';
+
+export default function withAuth(InnerComponent: FC) {
+  return function WrapperComponent(props: any) {
+    const { accessToken } = useAuthState();
+
+    if (accessToken) {
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      return <InnerComponent {...props} />;
+    }
+
+    return <Redirect to="/login" />;
+  };
+}

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -7,3 +7,4 @@ export * from './useThreadState';
 export * from './useSubThreadState';
 export * from './useSocketState';
 export * from './useEmojiState';
+export * from './useRedirectState';

--- a/client/src/hooks/useRedirectState.ts
+++ b/client/src/hooks/useRedirectState.ts
@@ -1,0 +1,13 @@
+import { useSelector } from 'react-redux';
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState } from '@/store/modules';
+
+const selectRedirectState = createSelector(
+  (state: RootState) => state.redirect,
+  (redirect) => redirect,
+);
+const useRedirectState = () => {
+  return useSelector(selectRedirectState);
+};
+
+export { useRedirectState };

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { useAuthState } from '@/hooks';
 
 const HomePage: React.FC = () => {
-  const { accessToken } = useAuthState();
-
-  return <>{accessToken ? <Redirect to="/client/1" /> : <Redirect to="/login" />}</>;
+  return <Redirect to="/client/1" />;
 };
 
 export default HomePage;

--- a/client/src/pages/WorkSpacePage.tsx
+++ b/client/src/pages/WorkSpacePage.tsx
@@ -66,14 +66,12 @@ const WorkSpacePage: React.FC = () => {
 
   return (
     <>
-      {accessToken ? (
-        <>
-          <Header />
-          <Container>
-            <LeftSideBar />
-            <ThreadListBox />
-            <SubThreadListBox />
-            {/* <>
+      <Header />
+      <Container>
+        <LeftSideBar />
+        <ThreadListBox />
+        <SubThreadListBox />
+        {/* <>
               {rightSideType &&
                 (checkValidOfRightSideType(rightSideType) ? (
                   <RightSideBar type={rightSideType} channelId={Number(channelId)} />
@@ -81,11 +79,7 @@ const WorkSpacePage: React.FC = () => {
                   history.goBack()
                 ))}
             </> */}
-          </Container>
-        </>
-      ) : (
-        <Redirect to="/login" />
-      )}
+      </Container>
     </>
   );
 };

--- a/client/src/pages/WorkSpacePage.tsx
+++ b/client/src/pages/WorkSpacePage.tsx
@@ -21,12 +21,6 @@ interface RightSideParams {
   threadId: string | undefined;
 }
 
-const checkValidOfRightSideType = (rightSideType: string | undefined) => {
-  return (
-    rightSideType === 'detail' || rightSideType === 'user_profile' || rightSideType === 'thread'
-  );
-};
-
 const WorkSpacePage: React.FC = () => {
   const { channelId }: RightSideParams = useParams();
   const { accessToken } = useAuthState();

--- a/client/src/pages/WorkSpacePage.tsx
+++ b/client/src/pages/WorkSpacePage.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect } from 'react';
-import { Redirect, useHistory, useParams } from 'react-router-dom';
-import { useAuthState, useUserState, useChannelState, useRedirectState } from '@/hooks';
-import { Header, LeftSideBar, ThreadListBox, RightSideBar, SubThreadListBox } from '@/components';
+import { useHistory, useParams } from 'react-router-dom';
+import { useUserState, useRedirectState } from '@/hooks';
+import {
+  Header,
+  LeftSideBar,
+  ThreadListBox,
+  RightSideBar,
+  SubThreadListBox,
+  SubThreadListHeader,
+  DetailHeader,
+  DetailBody,
+} from '@/components';
 import { isExistedChannel, isNumberTypeValue } from '@/utils/utils';
 import { socketConnectRequest, socketDisconnectRequest } from '@/store/modules/socket.slice';
 import { getEmojiListRequest } from '@/store/modules/emoji.slice';
@@ -17,13 +26,12 @@ const Container = styled.div`
 
 interface RightSideParams {
   channelId: string | undefined;
-  rightSideType: string | undefined;
+  rightSideType: 'detail' | 'user_profile' | 'thread' | undefined;
   threadId: string | undefined;
 }
 
 const WorkSpacePage: React.FC = () => {
-  const { channelId }: RightSideParams = useParams();
-  const { accessToken } = useAuthState();
+  const { channelId, rightSideType, threadId }: RightSideParams = useParams();
   const { userInfo } = useUserState();
   const history = useHistory();
   const dispatch = useDispatch();
@@ -64,15 +72,20 @@ const WorkSpacePage: React.FC = () => {
       <Container>
         <LeftSideBar />
         <ThreadListBox />
-        <SubThreadListBox />
-        {/* <>
-              {rightSideType &&
-                (checkValidOfRightSideType(rightSideType) ? (
-                  <RightSideBar type={rightSideType} channelId={Number(channelId)} />
-                ) : (
-                  history.goBack()
-                ))}
-            </> */}
+        {rightSideType === 'thread' && channelId && threadId && (
+          <RightSideBar
+            url={`/client/1/${+channelId}`}
+            header={<SubThreadListHeader />}
+            body={<SubThreadListBox />}
+          />
+        )}
+        {rightSideType === 'detail' && channelId && (
+          <RightSideBar
+            url={`/client/1/${+channelId}`}
+            header={<DetailHeader />}
+            body={<DetailBody />}
+          />
+        )}
       </Container>
     </>
   );

--- a/client/src/pages/WorkSpacePage.tsx
+++ b/client/src/pages/WorkSpacePage.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
-import { useAuthState, useUserState, useChannelState } from '@/hooks';
+import { useAuthState, useUserState, useChannelState, useRedirectState } from '@/hooks';
 import { Header, LeftSideBar, ThreadListBox, RightSideBar, SubThreadListBox } from '@/components';
 import { isExistedChannel, isNumberTypeValue } from '@/utils/utils';
 import { socketConnectRequest, socketDisconnectRequest } from '@/store/modules/socket.slice';
 import { getEmojiListRequest } from '@/store/modules/emoji.slice';
 import { useDispatch } from 'react-redux';
+import { setRedirect } from '@/store/modules/redirect.slice';
 
 import styled from 'styled-components';
 
@@ -32,6 +33,14 @@ const WorkSpacePage: React.FC = () => {
   const { userInfo } = useUserState();
   const history = useHistory();
   const dispatch = useDispatch();
+  const { url: redirectUrl } = useRedirectState();
+
+  useEffect(() => {
+    if (redirectUrl) {
+      history.push(redirectUrl);
+      dispatch(setRedirect({ url: null }));
+    }
+  }, [redirectUrl]);
 
   /* url에 채널 아이디가 없을 때, 최근에 접속한 채널로 이동 */
   useEffect(() => {

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -89,21 +89,23 @@ const channelSlice = createSlice({
     },
     updateChannelUnread(state, { payload }: PayloadAction<{ channel: Channel }>) {
       const { channel } = payload;
-      const idx = state.myChannelList.findIndex((c) => c.id === channel.id);
-      if (state.current) {
-        if (idx !== -1 && state.myChannelList[idx].id !== state.current.id) {
-          state.myChannelList[idx] = { ...state.myChannelList[idx], ...channel };
+      state.myChannelList = state.myChannelList.map((chan) => {
+        if (chan.id === channel.id) {
+          return { ...chan, ...channel };
         }
-      }
+        return chan;
+      });
     },
     updateChannelTopic(state, { payload }: PayloadAction<{ channel: Channel }>) {
       const { channel } = payload;
-      const idx = state.myChannelList.findIndex((c) => c.id === channel.id);
-      if (idx !== -1) {
-        state.myChannelList[idx] = { ...state.myChannelList[idx], topic: channel.topic };
-        if (state.current?.id === channel.id) {
-          state.current = channel;
+      state.myChannelList = state.myChannelList.map((chan) => {
+        if (chan.id === channel.id) {
+          return { ...chan, topic: channel.topic };
         }
+        return chan;
+      });
+      if (state.current?.id === channel.id) {
+        state.current = channel;
       }
     },
     updateChannelUsers(

--- a/client/src/store/modules/index.ts
+++ b/client/src/store/modules/index.ts
@@ -7,6 +7,7 @@ import userSlice, { USER } from './user.slice';
 import signupSlice, { SIGNUP } from './signup.slice';
 import socketSlice, { SOCKET } from './socket.slice';
 import emojiSlice, { EMOJI } from './emoji.slice';
+import redirectSlice, { REDIRECT } from './redirect.slice';
 
 const rootReducer = combineReducers({
   [CHANNEL]: channelSlice,
@@ -17,6 +18,7 @@ const rootReducer = combineReducers({
   [SIGNUP]: signupSlice,
   [SOCKET]: socketSlice,
   [EMOJI]: emojiSlice,
+  [REDIRECT]: redirectSlice,
 });
 
 export type RootState = ReturnType<typeof rootReducer>;

--- a/client/src/store/modules/redirect.slice.ts
+++ b/client/src/store/modules/redirect.slice.ts
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable no-param-reassign */
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from '@/store/modules';
+
+interface RedirectState {
+  url: string | null;
+}
+
+const redirectState: RedirectState = {
+  url: null,
+};
+
+const redirectSlice = createSlice({
+  name: 'redirect',
+  initialState: redirectState,
+  reducers: {
+    setRedirect(state, { payload }: PayloadAction<{ url: string | null }>) {
+      state.url = payload.url;
+    },
+  },
+});
+
+const selectRedirectState = (state: RootState) => state.redirect;
+
+export const selectRedirect = createSelector(selectRedirectState, (redirect) => redirect);
+export const REDIRECT = redirectSlice.name;
+export const { setRedirect } = redirectSlice.actions;
+
+export default redirectSlice.reducer;

--- a/client/src/store/sagas/channelSaga.ts
+++ b/client/src/store/sagas/channelSaga.ts
@@ -20,7 +20,8 @@ import {
   joinChannelSuccess,
   joinChannelFailure,
   joinChannelRequsetPayload,
-} from '../modules/channel.slice';
+} from '@/store/modules/channel.slice';
+import { setRedirect } from '@/store/modules/redirect.slice';
 
 function* loadChannels() {
   try {
@@ -98,6 +99,7 @@ function* createChannel(action: any) {
       });
       if (joinStatus === 200) {
         yield put(joinChannelSuccess({ users }));
+        yield put(setRedirect({ url: `/client/1/${data.channel.insertId}` }));
       }
     }
   } catch (err) {

--- a/client/src/store/sagas/channelSaga.ts
+++ b/client/src/store/sagas/channelSaga.ts
@@ -92,7 +92,7 @@ function* createChannel(action: any) {
       };
 
       yield put(createChannelSuccess({ channel, joinedListUser: [joinedUser] }));
-      const { joinStatus } = yield call(channelService.joinChannel, {
+      const { status: joinStatus } = yield call(channelService.joinChannel, {
         users,
         channelId: data.channel.insertId,
       });


### PR DESCRIPTION
## 구현 내용

### 1. 우측 사이드바 공통 컴포넌트 구현
- 디테일 박스 디자인 일부 완성
- 서브스레드 디자인 완성

### 2.  rightSideBar parameter에 정규식 적용
- 이제 detail / user_profile / thread 일때만 받습니다.

### 3. findIndex 쓰는 코드 map으로 대체
- 바꿨습니다

### 4. withAuth hoc 구현
- 이제 accessToken으로 체크하고 Login으로 보내야 한다면 withAuth로 컴포넌트를 감싸면 됩니다.

### 5. redirect saga, reducer 구현
- saga에서 redirect 을 해야하는 경우 redirect state의 url에 원하는 url을 주입하면, url을 사용하고있는 페이지 컴포넌트에서 history.push를 대신 해줍니다.

### 6. 401 리다이렉션 처리
- 로그인 페이지로 보냅니다.

### 7. 이모지 디자인
- 이모지 둥글게 바꿔놨습니다.
- 아직 순원님이 색상을 state 안쓰고 하는 쪽으로 리팩토링 하고계신것 같아서 조금만 건드렸습니다.

![image](https://user-images.githubusercontent.com/61396464/101810191-d36b0100-3b5b-11eb-937d-2a485f5c2217.png)

![image](https://user-images.githubusercontent.com/61396464/101810210-d9f97880-3b5b-11eb-9729-88cc4da2938b.png)

