### PR TITLE
내가 직접 채널을 검색해서 채널에 가입하는 경우를 소켓으로 구현

### DIFF
--- a/client/src/components/ChannelListBox/ChannelListHeader/FindChannelModal/FindChannelModalBody/FindChannelModalBody.tsx
+++ b/client/src/components/ChannelListBox/ChannelListHeader/FindChannelModal/FindChannelModalBody/FindChannelModalBody.tsx
@@ -31,7 +31,6 @@ const FindChannelModalBody: React.FC<FindChannelModalProps> = ({
   }, []);
 
   const clickJoinButton = ({ channel }: { channel: Channel }) => {
-    console.log(channel);
     if (userInfo) {
       const users = [
         { userId: userInfo.id, displayName: userInfo.displayName, image: userInfo.image },
@@ -39,7 +38,7 @@ const FindChannelModalBody: React.FC<FindChannelModalProps> = ({
       dispatch(
         sendMessageRequest({
           type: SOCKET_MESSAGE_TYPE.CHANNEL,
-          subType: CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS,
+          subType: CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL,
           channel,
           users,
           room: channel.name,

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -91,7 +91,10 @@ function subscribeSocket(socket: Socket) {
           return;
         }
 
-        if (subType === CHANNEL_SUBTYPE.MAKE_DM) {
+        if (
+          subType === CHANNEL_SUBTYPE.MAKE_DM ||
+          subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL
+        ) {
           emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
         }
 

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -57,4 +57,5 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
   MAKE_DM: 'make_dm',
+  JOIN_CHANNEL: 'join_channel',
 };

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -57,5 +57,5 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
   MAKE_DM: 'make_dm',
-  JOIN_CHANNEL: 'join_channel',
+  FIND_AND_JOIN_CHANNEL: 'find_and_join_channel',
 };

--- a/server/src/lib/socket.ts
+++ b/server/src/lib/socket.ts
@@ -261,7 +261,10 @@ export const bindSocketServer = (server: http.Server): void => {
           return;
         }
 
-        if (subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS) {
+        if (
+          subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS ||
+          subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL
+        ) {
           if (channel?.id && users) {
             try {
               const joinUsers: [number[]] = users.reduce((acc: any, cur: JoinedUser) => {
@@ -285,6 +288,13 @@ export const bindSocketServer = (server: http.Server): void => {
                 channel,
                 room,
               });
+
+              if (subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL) {
+                socket.emit(MESSAGE, {
+                  type,
+                  subType: CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL,
+                });
+              }
             } catch (err) {
               console.log(err);
             }

--- a/server/src/models/channels.model.ts
+++ b/server/src/models/channels.model.ts
@@ -77,7 +77,8 @@ export const channelModel = {
     return pool.execute(sql, [topic, channelId]);
   },
   getNotJoinedChannels({ userId }: { userId: number }): any {
-    const sql = `SELECT * FROM channel
+    const sql = `SELECT id, owner_id as ownerId, name, channel_type as channelType, is_public as isPublic, 
+    is_deleted as isDeleted, member_count as memberCount, description, topic FROM channel
     WHERE channel.is_public = 1 AND channel.id NOT IN
     (SELECT channel.id FROM channel 
     JOIN user_channel 

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -47,7 +47,7 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
   MAKE_DM: 'make_dm',
-  JOIN_CHANNEL: `join_channel`,
+  FIND_AND_JOIN_CHANNEL: `find_and_join_channel`,
 };
 
 export const GET_EMOJI_OF_THREAD_SQL = `

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -47,6 +47,7 @@ export const CHANNEL_SUBTYPE = {
   UPDATE_CHANNEL_UNREAD: 'update_channel_unread',
   UPDATE_CHANNEL_USERS: 'update_channel_users',
   MAKE_DM: 'make_dm',
+  JOIN_CHANNEL: `join_channel`,
 };
 
 export const GET_EMOJI_OF_THREAD_SQL = `


### PR DESCRIPTION
# 오늘 한 일
### 1. 가입하지 않은 public 채널을 직접 찾아서 JOIN하는 경우를 소켓으로 구현
ex.) A라는 유저가 가입하지 않은 public 채널인 프론트 팀 채널을 직접 가입하는 경우
1. A라는 유저만 채널 목록을 다시 불러오면 된다.
2. 프론트 팀 채널에 원래 존재하고 있었던 사람들 중 A가 가입하는 당시에 프론트 팀에서 활동하고 있던 사람들은  A라는 유저가 가입됬다고 실시간으로 알아야 한다.