### PR TITLE
유저 소켓 이벤트 생성, 채널 소켓에서 서비스 로직을 분리

### DIFF
--- a/client/src/components/ThreadListBox/ThreadListBox.tsx
+++ b/client/src/components/ThreadListBox/ThreadListBox.tsx
@@ -2,10 +2,15 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { INPUT_BOX_TYPE } from '@/utils/constants';
+import { INPUT_BOX_TYPE, SOCKET_MESSAGE_TYPE } from '@/utils/constants';
 import { ThreadInputBox } from '@/components';
 import { loadChannelRequest } from '@/store/modules/channel.slice';
-import { enterRoomRequest, leaveRoomRequest } from '@/store/modules/socket.slice';
+import {
+  enterRoomRequest,
+  leaveRoomRequest,
+  sendMessageRequest,
+} from '@/store/modules/socket.slice';
+import { setEditDefault } from '@/store/modules/user.slice';
 import { useChannelState, useSocketState, useUserState } from '@/hooks';
 import { isNumberTypeValue } from '@/utils/utils';
 import { getThreadRequest } from '@/store/modules/thread.slice';
@@ -22,15 +27,16 @@ const Container = styled.div`
 
 interface RightSideParams {
   channelId: string;
+  threadId: string;
 }
 
 const ThreadListBox = () => {
-  const { channelId }: RightSideParams = useParams();
+  const { channelId, threadId }: RightSideParams = useParams();
 
   const dispatch = useDispatch();
 
   const { current } = useChannelState();
-  const { userInfo } = useUserState();
+  const { userInfo, edit } = useUserState();
   const { socket } = useSocketState();
 
   useEffect(() => {
@@ -46,6 +52,19 @@ const ThreadListBox = () => {
       dispatch(getThreadRequest({ channelId: +channelId }));
     }
   }, [channelId]);
+
+  useEffect(() => {
+    if (edit.success && userInfo) {
+      dispatch(
+        sendMessageRequest({
+          type: SOCKET_MESSAGE_TYPE.USER,
+          user: userInfo,
+          parentThreadId: threadId,
+        }),
+      );
+      dispatch(setEditDefault());
+    }
+  }, [edit]);
 
   useEffect(() => {
     if (current && socket) {

--- a/client/src/components/ThreadListBox/ThreadListBox.tsx
+++ b/client/src/components/ThreadListBox/ThreadListBox.tsx
@@ -10,7 +10,6 @@ import {
   leaveRoomRequest,
   sendMessageRequest,
 } from '@/store/modules/socket.slice';
-import { setEditDefault } from '@/store/modules/user.slice';
 import { useChannelState, useSocketState, useUserState } from '@/hooks';
 import { isNumberTypeValue } from '@/utils/utils';
 import { getThreadRequest } from '@/store/modules/thread.slice';
@@ -62,7 +61,6 @@ const ThreadListBox = () => {
           parentThreadId: threadId,
         }),
       );
-      dispatch(setEditDefault());
     }
   }, [edit]);
 

--- a/client/src/store/modules/user.slice.ts
+++ b/client/src/store/modules/user.slice.ts
@@ -90,6 +90,11 @@ const userSlice = createSlice({
         state.userInfo.lastChannelId = payload.channelId;
       }
     },
+    setEditDefault(state) {
+      state.edit.loading = false;
+      state.edit.success = false;
+      state.edit.err = null;
+    },
   },
 });
 
@@ -105,6 +110,7 @@ export const {
   searchUserSuccess,
   searchUserFailure,
   setLastChannel,
+  setEditDefault,
 } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/client/src/store/modules/user.slice.ts
+++ b/client/src/store/modules/user.slice.ts
@@ -90,11 +90,6 @@ const userSlice = createSlice({
         state.userInfo.lastChannelId = payload.channelId;
       }
     },
-    setEditDefault(state) {
-      state.edit.loading = false;
-      state.edit.success = false;
-      state.edit.err = null;
-    },
   },
 });
 
@@ -110,7 +105,6 @@ export const {
   searchUserSuccess,
   searchUserFailure,
   setLastChannel,
-  setEditDefault,
 } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -8,15 +8,25 @@ import {
   enterRoomRequest,
   leaveRoomRequest,
 } from '@/store/modules/socket.slice';
-import { addThread, changeEmojiOfThread, updateSubThreadInfo } from '@/store/modules/thread.slice';
-import { changeEmojiOfSubThread, addSubThread } from '@/store/modules/subThread.slice';
-
 import {
+  addThread,
+  getThreadRequest,
+  changeEmojiOfThread,
+  updateSubThreadInfo,
+} from '@/store/modules/thread.slice';
+import {
+  changeEmojiOfSubThread,
+  addSubThread,
+  getSubThreadRequest,
+} from '@/store/modules/subThread.slice';
+import {
+  loadChannelRequest,
   updateChannelUnread,
   updateChannelTopic,
   updateChannelUsers,
   setReloadMyChannelListFlag,
 } from '@/store/modules/channel.slice';
+
 import io from 'socket.io-client';
 import { eventChannel } from 'redux-saga';
 import { SOCKET_EVENT_TYPE, CHANNEL_SUBTYPE } from '@/utils/constants';
@@ -70,7 +80,14 @@ function subscribeSocket(socket: Socket) {
         return;
       }
       if (isUserEvent(data)) {
-        // TODO: User 이벤트 처리
+        const { channelId, user, parentThreadId } = data;
+        if (channelId && user) {
+          emit(loadChannelRequest({ channelId: +channelId, userId: user.id }));
+          emit(getThreadRequest({ channelId: +channelId }));
+          if (parentThreadId) {
+            emit(getSubThreadRequest({ parentId: +parentThreadId }));
+          }
+        }
         return;
       }
       if (isChannelEvent(data)) {

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -110,10 +110,12 @@ function subscribeSocket(socket: Socket) {
 
         if (subType === CHANNEL_SUBTYPE.MAKE_DM) {
           emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
+          return;
         }
 
         if (subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL) {
           emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
+          return;
         }
 
         return;

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -108,10 +108,11 @@ function subscribeSocket(socket: Socket) {
           return;
         }
 
-        if (
-          subType === CHANNEL_SUBTYPE.MAKE_DM ||
-          subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL
-        ) {
+        if (subType === CHANNEL_SUBTYPE.MAKE_DM) {
+          emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
+        }
+
+        if (subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL) {
           emit(setReloadMyChannelListFlag({ reloadMyChannelList: true }));
         }
 

--- a/client/src/types/socket.ts
+++ b/client/src/types/socket.ts
@@ -77,7 +77,9 @@ export interface EmojiEvent {
 
 export interface UserEvent {
   type: string;
-  user: User;
+  user?: User;
+  channelId?: number;
+  parentThreadId: string | undefined;
 }
 
 export interface ChannelEvent {

--- a/server/src/lib/socket.ts
+++ b/server/src/lib/socket.ts
@@ -280,10 +280,25 @@ export const bindSocketServer = (server: http.Server): void => {
           return;
         }
 
-        if (
-          subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS ||
-          subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL
-        ) {
+        if (subType === CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS) {
+          if (channel?.id && users) {
+            try {
+              const joinedUsers = await channelService.updateChannelUsers({ users, channel });
+              namespace.emit(MESSAGE, {
+                type,
+                subType: CHANNEL_SUBTYPE.UPDATE_CHANNEL_USERS,
+                users: joinedUsers,
+                channel,
+                room,
+              });
+            } catch (err) {
+              console.error(err.message);
+            }
+            return;
+          }
+        }
+
+        if (subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL) {
           if (channel?.id && users) {
             try {
               const joinedUsers = await channelService.updateChannelUsers({ users, channel });
@@ -295,14 +310,12 @@ export const bindSocketServer = (server: http.Server): void => {
                 room,
               });
 
-              if (subType === CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL) {
-                socket.emit(MESSAGE, {
-                  type,
-                  subType: CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL,
-                });
-              }
+              socket.emit(MESSAGE, {
+                type,
+                subType: CHANNEL_SUBTYPE.FIND_AND_JOIN_CHANNEL,
+              });
             } catch (err) {
-              console.log(err);
+              console.error(err.message);
             }
             return;
           }
@@ -329,7 +342,7 @@ export const bindSocketServer = (server: http.Server): void => {
                 channel,
               });
             } catch (err) {
-              console.error(err);
+              console.error(err.message);
             }
           }
           return;

--- a/server/src/services/channel.service.ts
+++ b/server/src/services/channel.service.ts
@@ -1,0 +1,98 @@
+import { channelModel } from '@/models';
+import { join } from 'path';
+
+interface JoinedUser {
+  userId: number;
+  displayName: string;
+  image: string;
+}
+
+interface Channel {
+  id?: number; // 채널 생성시 아이디가 없음
+  ownerId: number;
+  name: string;
+  channelType: number;
+  topic: string;
+  isPublic: number;
+  memberCount: number;
+  description: string;
+  createdAt?: string;
+  updatedAt?: string;
+  unreadMessage?: boolean;
+}
+
+interface updateChannelTopicParams {
+  channelId: number;
+  topic: string;
+}
+
+interface updateChannelUsersParams {
+  users: JoinedUser[];
+  channel: Channel;
+}
+
+interface makeDMParams {
+  ownerId: number;
+  name: string;
+  memberCount: number;
+  isPublic: number;
+  description: string;
+  channelType: number;
+  users: JoinedUser[];
+}
+
+export const channelService = {
+  async updateChannelTopic({ channelId, topic }: updateChannelTopicParams): Promise<void> {
+    await channelModel.modifyTopic({ channelId, topic });
+  },
+  async updateChannelUsers({ users, channel }: updateChannelUsersParams): Promise<JoinedUser> {
+    const selectedUsers: [number[]] = users.reduce((acc: any, cur: JoinedUser) => {
+      acc.push([cur.userId, channel.id]);
+      return acc;
+    }, []);
+
+    await channelModel.joinChannel({
+      selectedUsers,
+      prevMemberCount: channel.memberCount,
+      channelId: channel.id,
+    });
+    const [joinedUsers] = await channelModel.getChannelUser({
+      channelId: channel.id,
+    });
+
+    return joinedUsers;
+  },
+  async makeDM({
+    ownerId,
+    name,
+    memberCount,
+    isPublic,
+    description,
+    channelType,
+    users,
+  }: makeDMParams): Promise<void> {
+    const [newChannel] = await channelModel.createChannel({
+      ownerId,
+      name,
+      memberCount,
+      isPublic,
+      description,
+      channelType,
+    });
+
+    const [joinedUsers] = await channelModel.getChannelUser({
+      channelId: newChannel.insertId,
+    });
+
+    const selectedUsers: [number[]] = users.reduce((acc: any, cur) => {
+      acc.push([cur.userId, newChannel.insertId]);
+      return acc;
+    }, []);
+
+    await channelModel.joinChannel({
+      channelId: newChannel.insertId,
+      prevMemberCount: joinedUsers.length,
+      selectedUsers,
+    });
+  },
+};


### PR DESCRIPTION
# 오늘 한 일
### 1. 유저 소켓에서 이벤트 생성
- 유저가 변경되는 이벤트가 일어나면 쓰레드 리스트 헤더, 메인 쓰레드, 서브 쓰레드에서 변경이 일어나게 함
![Peek 2020-12-14 22-43](https://user-images.githubusercontent.com/50985451/102096248-d588d480-3e67-11eb-8286-5f9acd5c9561.gif)

### 2. 채널 소켓에서 서비스 로직을 분리
- 소켓을 담당하는 코드가 너무 길어져 서비스 로직으로 분리