### PR TITLE
로그아웃 시 불필요하게 남아있는 state 초기화

### DIFF
--- a/client/src/components/EmailBox/EmailBox.tsx
+++ b/client/src/components/EmailBox/EmailBox.tsx
@@ -123,6 +123,12 @@ const EmailBox: React.FC = () => {
     }
   }, [checkExistEmail]);
 
+  useEffect(() => {
+    return () => {
+      dispatch(resetCheckExistEmailState());
+    };
+  }, []);
+
   const warningMessage = !valid ? notValidEmailMessage : existEmailMessage;
 
   return (

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
-import { getUserRequest } from '@/store/modules/user.slice';
+import { getUserRequest, resetUserInfo } from '@/store/modules/user.slice';
 import { flex } from '@/styles/mixin';
 import { useAuthState, useUserState } from '@/hooks';
 import { logoutRequest } from '@/store/modules/auth.slice';
+
 import { DimModal, UserStateIcon, ClockIcon, Popover } from '@/components';
 import theme from '@/styles/theme';
 import { UserProfileModalHeader, UserProfileModalBody } from './UserProfileBox';
@@ -139,6 +140,7 @@ const Header: React.FC = () => {
 
   const handleLogout = () => {
     dispatch(logoutRequest());
+    dispatch(resetUserInfo());
   };
 
   useEffect(() => {

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
-import { getUserRequest, resetUserInfo } from '@/store/modules/user.slice';
+import { getUserRequest } from '@/store/modules/user.slice';
 import { flex } from '@/styles/mixin';
 import { useAuthState, useUserState } from '@/hooks';
 import { logoutRequest } from '@/store/modules/auth.slice';
@@ -140,7 +140,6 @@ const Header: React.FC = () => {
 
   const handleLogout = () => {
     dispatch(logoutRequest());
-    dispatch(resetUserInfo());
   };
 
   useEffect(() => {

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -5,7 +5,6 @@ import { getUserRequest } from '@/store/modules/user.slice';
 import { flex } from '@/styles/mixin';
 import { useAuthState, useUserState } from '@/hooks';
 import { logoutRequest } from '@/store/modules/auth.slice';
-
 import { DimModal, UserStateIcon, ClockIcon, Popover } from '@/components';
 import theme from '@/styles/theme';
 import { UserProfileModalHeader, UserProfileModalBody } from './UserProfileBox';

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -38,6 +38,9 @@ const channelSlice = createSlice({
   name: 'channel',
   initialState,
   reducers: {
+    resetChannelState() {
+      return initialState;
+    },
     loadChannelsRequest() {},
     loadChannelsSuccess(state, action) {
       state.channelList = action.payload.channelList;
@@ -130,6 +133,7 @@ const channelSlice = createSlice({
 
 export const CHANNEL = channelSlice.name;
 export const {
+  resetChannelState,
   loadChannelsRequest,
   loadChannelsSuccess,
   loadChannelsFailure,

--- a/client/src/store/modules/duplicatedChannel.slice.ts
+++ b/client/src/store/modules/duplicatedChannel.slice.ts
@@ -19,7 +19,7 @@ const duplicatedChannelSlice = createSlice({
   initialState,
   reducers: {
     checkDuplicateRequest(state, { payload }: PayloadAction<{ channelName: string }>) {
-      state.loading = true;
+      return { ...initialState, loading: true };
     },
     checkDuplicateSuccess(state, { payload }: PayloadAction<{ isDuplicated: boolean }>) {
       state.loading = false;

--- a/client/src/store/modules/signup.slice.ts
+++ b/client/src/store/modules/signup.slice.ts
@@ -62,6 +62,8 @@ const signupSlice = createSlice({
   reducers: {
     verifyEmailSendRequest(state, action: PayloadAction<VerifyEmailSendRequestPayload>) {
       state.verify.loading = true;
+      state.verify.verifyCode = null;
+      state.verify.err = null;
     },
     verifyEmailSendSuccess(state, action: PayloadAction<VerifyEmailSendSuccessPayload>) {
       const { verifyCode, email } = action.payload;

--- a/client/src/store/modules/subThread.slice.ts
+++ b/client/src/store/modules/subThread.slice.ts
@@ -22,6 +22,9 @@ const subThreadSlice = createSlice({
   name: 'subThread',
   initialState: subThreadListState,
   reducers: {
+    resetSubThreadState() {
+      return subThreadListState;
+    },
     getSubThreadRequest(state, action: PayloadAction<GetSubThreadRequestPayload>) {},
     getSubThreadSuccess(state, action: PayloadAction<SubThreadBox>) {
       state.parentThread = action.payload.parentThread;
@@ -75,6 +78,7 @@ const subThreadSlice = createSlice({
 
 export const SUBTHREAD = subThreadSlice.name;
 export const {
+  resetSubThreadState,
   getSubThreadRequest,
   getSubThreadSuccess,
   getSubThreadFailure,

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -47,6 +47,9 @@ const threadSlice = createSlice({
   name: 'thread',
   initialState: threadListState,
   reducers: {
+    resetThreadState() {
+      return threadListState;
+    },
     getThreadRequest(state, action: PayloadAction<getThreadRequestPayload>) {
       state.loading = true;
       state.nextThreadId = null;
@@ -152,6 +155,7 @@ const threadSlice = createSlice({
 
 export const THREAD = threadSlice.name;
 export const {
+  resetThreadState,
   getThreadRequest,
   getThreadSuccess,
   getThreadFailure,

--- a/client/src/store/modules/user.slice.ts
+++ b/client/src/store/modules/user.slice.ts
@@ -90,6 +90,9 @@ const userSlice = createSlice({
         state.userInfo.lastChannelId = payload.channelId;
       }
     },
+    resetUserInfo(state) {
+      state.userInfo = null;
+    },
   },
 });
 
@@ -105,6 +108,7 @@ export const {
   searchUserSuccess,
   searchUserFailure,
   setLastChannel,
+  resetUserInfo,
 } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/client/src/store/modules/user.slice.ts
+++ b/client/src/store/modules/user.slice.ts
@@ -52,6 +52,9 @@ const userSlice = createSlice({
   name: 'user',
   initialState: userState,
   reducers: {
+    resetUserState() {
+      return userState;
+    },
     getUserRequest(state, action: PayloadAction<{ userId: number }>) {},
     getUserSuccess(state, { payload }: PayloadAction<{ userInfo: User }>) {
       state.userInfo = payload.userInfo;
@@ -90,14 +93,12 @@ const userSlice = createSlice({
         state.userInfo.lastChannelId = payload.channelId;
       }
     },
-    resetUserInfo(state) {
-      state.userInfo = null;
-    },
   },
 });
 
 export const USER = userSlice.name;
 export const {
+  resetUserState,
   getUserRequest,
   getUserSuccess,
   getUserFailure,
@@ -108,7 +109,6 @@ export const {
   searchUserSuccess,
   searchUserFailure,
   setLastChannel,
-  resetUserInfo,
 } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/client/src/store/sagas/authSaga.ts
+++ b/client/src/store/sagas/authSaga.ts
@@ -8,6 +8,10 @@ import {
   logoutFailure,
   LoginRequestPayload,
 } from '@/store/modules/auth.slice';
+import { resetUserState } from '@/store/modules/user.slice';
+import { resetChannelState } from '@/store/modules/channel.slice';
+import { resetThreadState } from '@/store/modules/thread.slice';
+import { resetSubThreadState } from '@/store/modules/subThread.slice';
 import { authService } from '@/services';
 
 function* login({ email, pw }: LoginRequestPayload) {
@@ -35,6 +39,12 @@ function* logout() {
       localStorage.removeItem('refreshToken');
       localStorage.removeItem('userId');
       yield put(logoutSuccess());
+      yield all([
+        put(resetUserState()),
+        put(resetChannelState()),
+        put(resetThreadState()),
+        put(resetSubThreadState()),
+      ]);
     }
   } catch (err) {
     yield put(logoutFailure());


### PR DESCRIPTION
## 구현 내용

- 로그아웃 시 기존 정보가 남아있어서, 다른 사용자로 로그인할 때 그대로 보이던 문제를 해결했습니다.
- 회원 가입시 코드 화면에서 이동할 떄도, 비슷하게 남아있던 state 들을 없애도록 변경했습니다.