### PR TITLE
유저 프로필 변경 이벤트가 발생한 경우, 원래 정보에서 유저 프로필이 변경된 곳만 교체해주는 형식으로 코드 수정 

### DIFF
--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -2,9 +2,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { JoinedUser, Channel, User, ChannelInfo } from '@/types';
-import { userInfo } from 'os';
-import { userService } from '@/services';
-import { actionChannel } from 'redux-saga/effects';
 
 interface ChannelState {
   channelList: Channel[];

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -2,6 +2,9 @@
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { JoinedUser, Channel, User, ChannelInfo } from '@/types';
+import { userInfo } from 'os';
+import { userService } from '@/services';
+import { actionChannel } from 'redux-saga/effects';
 
 interface ChannelState {
   channelList: Channel[];
@@ -125,6 +128,18 @@ const channelSlice = createSlice({
     ) {
       state.reloadMyChannelList = payload.reloadMyChannelList;
     },
+    replaceUserAfterUpdateUserProfile(
+      state,
+      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+    ) {
+      const { changeUserInfo } = payload;
+      state.users = state.users.map((u) => {
+        if (u.userId === changeUserInfo.userId) {
+          return { ...u, displayName: changeUserInfo.displayName, image: changeUserInfo.image };
+        }
+        return u;
+      });
+    },
   },
 });
 
@@ -150,5 +165,6 @@ export const {
   updateChannelTopic,
   updateChannelUsers,
   setReloadMyChannelListFlag,
+  replaceUserAfterUpdateUserProfile,
 } = channelSlice.actions;
 export default channelSlice.reducer;

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -127,12 +127,16 @@ const channelSlice = createSlice({
     },
     replaceUserAfterUpdateUserProfile(
       state,
-      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+      { payload }: PayloadAction<{ changedJoinedUserInfo: JoinedUser }>,
     ) {
-      const { changeUserInfo } = payload;
+      const { changedJoinedUserInfo } = payload;
       state.users = state.users.map((u) => {
-        if (u.userId === changeUserInfo.userId) {
-          return { ...u, displayName: changeUserInfo.displayName, image: changeUserInfo.image };
+        if (u.userId === changedJoinedUserInfo.userId) {
+          return {
+            ...u,
+            displayName: changedJoinedUserInfo.displayName,
+            image: changedJoinedUserInfo.image,
+          };
         }
         return u;
       });

--- a/client/src/store/modules/subThread.slice.ts
+++ b/client/src/store/modules/subThread.slice.ts
@@ -72,16 +72,16 @@ const subThreadSlice = createSlice({
     },
     replaceSubThreadsAfterUpdateUserProfile(
       state,
-      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+      { payload }: PayloadAction<{ changedJoinedUserInfo: JoinedUser }>,
     ) {
-      const { changeUserInfo } = payload;
+      const { changedJoinedUserInfo } = payload;
       if (state.subThreadList) {
         state.subThreadList = state.subThreadList.map((subThread) => {
-          if (subThread.userId === changeUserInfo.userId) {
+          if (subThread.userId === changedJoinedUserInfo.userId) {
             return {
               ...subThread,
-              displayName: changeUserInfo.displayName,
-              image: changeUserInfo.image,
+              displayName: changedJoinedUserInfo.displayName,
+              image: changedJoinedUserInfo.image,
             };
           }
           return subThread;

--- a/client/src/store/modules/subThread.slice.ts
+++ b/client/src/store/modules/subThread.slice.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { Thread, initialThread, EmojiOfThread } from '@/types';
+import { Thread, initialThread, EmojiOfThread, JoinedUser } from '@/types';
 
 interface SubThreadBox {
   parentThread: Thread;
@@ -70,6 +70,24 @@ const subThreadSlice = createSlice({
         targetThread.emoji = payload.emoji;
       }
     },
+    replaceSubThreadsAfterUpdateUserProfile(
+      state,
+      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+    ) {
+      const { changeUserInfo } = payload;
+      if (state.subThreadList) {
+        state.subThreadList = state.subThreadList.map((subThread) => {
+          if (subThread.userId === changeUserInfo.userId) {
+            return {
+              ...subThread,
+              displayName: changeUserInfo.displayName,
+              image: changeUserInfo.image,
+            };
+          }
+          return subThread;
+        });
+      }
+    },
   },
 });
 
@@ -82,6 +100,7 @@ export const {
   deleteSubThread,
   deleteSubParentThread,
   changeEmojiOfSubThread,
+  replaceSubThreadsAfterUpdateUserProfile,
 } = subThreadSlice.actions; // action 나눠서 export 하기
 
 export default subThreadSlice.reducer;

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -149,16 +149,16 @@ const threadSlice = createSlice({
     },
     replaceThreadsAfterUpdateUserProfile(
       state,
-      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+      { payload }: PayloadAction<{ changedJoinedUserInfo: JoinedUser }>,
     ) {
-      const { changeUserInfo } = payload;
+      const { changedJoinedUserInfo } = payload;
       if (state.threadList) {
         state.threadList = state.threadList.map((thread) => {
-          if (thread.userId === changeUserInfo.userId) {
+          if (thread.userId === changedJoinedUserInfo.userId) {
             return {
               ...thread,
-              displayName: changeUserInfo.displayName,
-              image: changeUserInfo.image,
+              displayName: changedJoinedUserInfo.displayName,
+              image: changedJoinedUserInfo.image,
             };
           }
           return thread;

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable no-param-reassign */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { EmojiOfThread, Thread, ThreadResponse } from '@/types';
+import { EmojiOfThread, JoinedUser, Thread, ThreadResponse } from '@/types';
 
 interface ThreadState {
   threadList: Thread[] | null;
@@ -147,6 +147,24 @@ const threadSlice = createSlice({
         targetThread.emoji = payload.emoji;
       }
     },
+    replaceThreadsAfterUpdateUserProfile(
+      state,
+      { payload }: PayloadAction<{ changeUserInfo: JoinedUser }>,
+    ) {
+      const { changeUserInfo } = payload;
+      if (state.threadList) {
+        state.threadList = state.threadList.map((thread) => {
+          if (thread.userId === changeUserInfo.userId) {
+            return {
+              ...thread,
+              displayName: changeUserInfo.displayName,
+              image: changeUserInfo.image,
+            };
+          }
+          return thread;
+        });
+      }
+    },
   },
 });
 
@@ -169,6 +187,7 @@ export const {
   addThreadListRequest,
   addThreadListSuccess,
   addThreadListFailure,
+  replaceThreadsAfterUpdateUserProfile,
 } = threadSlice.actions; // action 나눠서 export 하기
 
 export default threadSlice.reducer;

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -140,15 +140,15 @@ function subscribeSocket(socket: Socket) {
       if (isUserEvent(data)) {
         const { channelId, user, parentThreadId } = data;
         if (channelId && user) {
-          const changeUserInfo = {
+          const changedJoinedUserInfo = {
             userId: user?.id,
             displayName: user?.displayName,
             image: user?.image,
           };
-          emit(replaceUserAfterUpdateUserProfile({ changeUserInfo }));
-          emit(replaceThreadsAfterUpdateUserProfile({ changeUserInfo }));
+          emit(replaceUserAfterUpdateUserProfile({ changedJoinedUserInfo }));
+          emit(replaceThreadsAfterUpdateUserProfile({ changedJoinedUserInfo }));
           if (parentThreadId) {
-            emit(replaceSubThreadsAfterUpdateUserProfile({ changeUserInfo }));
+            emit(replaceSubThreadsAfterUpdateUserProfile({ changedJoinedUserInfo }));
           }
         }
 

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -14,22 +14,22 @@ import {
   updateAddSubThreadInfo,
   deleteThread,
   updateDeleteSubThreadInfo,
-  getThreadRequest,
+  replaceThreadsAfterUpdateUserProfile,
 } from '@/store/modules/thread.slice';
 import {
   changeEmojiOfSubThread,
   addSubThread,
   deleteSubThread,
   deleteSubParentThread,
-  getSubThreadRequest,
+  replaceSubThreadsAfterUpdateUserProfile,
 } from '@/store/modules/subThread.slice';
 
 import {
-  loadChannelRequest,
   updateChannelUnread,
   updateChannelTopic,
   updateChannelUsers,
   setReloadMyChannelListFlag,
+  replaceUserAfterUpdateUserProfile,
 } from '@/store/modules/channel.slice';
 
 import io from 'socket.io-client';
@@ -140,12 +140,18 @@ function subscribeSocket(socket: Socket) {
       if (isUserEvent(data)) {
         const { channelId, user, parentThreadId } = data;
         if (channelId && user) {
-          emit(loadChannelRequest({ channelId: +channelId, userId: user.id }));
-          emit(getThreadRequest({ channelId: +channelId }));
+          const changeUserInfo = {
+            userId: user?.id,
+            displayName: user?.displayName,
+            image: user?.image,
+          };
+          emit(replaceUserAfterUpdateUserProfile({ changeUserInfo }));
+          emit(replaceThreadsAfterUpdateUserProfile({ changeUserInfo }));
           if (parentThreadId) {
-            emit(getSubThreadRequest({ parentId: +parentThreadId }));
+            emit(replaceSubThreadsAfterUpdateUserProfile({ changeUserInfo }));
           }
         }
+
         return;
       }
       if (isChannelEvent(data)) {


### PR DESCRIPTION
스크럼 때 나눈 내용으로 유저 프로필 변경 소켓 동작을 수정하였습니다.
1.  유저 프로필이 변경되면 변경된 유저가 작성한 쓰레드나 서브쓰레드 내용을 모두 불러오지 않고 해당하는 부분만 정보를 교체하는 형식으로 함수를 구현하였습니다. 
2. 쓰레드 리스트 헤더에서도 유저들 목록에서 프로필이 바뀐 유저 정보만 교체하는 형식으로 작성하였습니다.