### PR TITLE
채널 스토어의 안쓰는 상태를 삭제

### DIFF
--- a/client/src/hooks/useChannelState.ts
+++ b/client/src/hooks/useChannelState.ts
@@ -5,20 +5,12 @@ import { RootState } from '@/store/modules';
 const selectChannelState = (state: RootState) => state.channel;
 const selectChannel = createSelector(selectChannelState, (channels) => channels);
 
-const selectChannelListState = (state: RootState) => state.channel.channelList;
-const selectChannelList = (idx: number) =>
-  createSelector(selectChannelListState, (channelList) => channelList[idx]);
-
 const selectJoinChannelListState = (state: RootState) => state.channel.myChannelList;
 const selectJoinChannelList = (idx: number) =>
   createSelector(selectJoinChannelListState, (joinChannelList) => joinChannelList[idx]);
 
 export const useChannelState = () => {
   return useSelector(selectChannel);
-};
-
-export const useChannelList = (idx: number) => {
-  return useSelector(selectChannelList(idx));
 };
 
 export const useJoinChannelListState = (idx: number) => {

--- a/client/src/store/modules/channel.slice.ts
+++ b/client/src/store/modules/channel.slice.ts
@@ -4,7 +4,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { JoinedUser, Channel, User, ChannelInfo } from '@/types';
 
 interface ChannelState {
-  channelList: Channel[];
   myChannelList: Channel[];
   current: Channel | null;
   users: JoinedUser[];
@@ -12,7 +11,6 @@ interface ChannelState {
 }
 
 const initialState: ChannelState = {
-  channelList: [],
   myChannelList: [],
   current: null,
   users: [],
@@ -41,13 +39,6 @@ const channelSlice = createSlice({
     resetChannelState() {
       return initialState;
     },
-    loadChannelsRequest() {},
-    loadChannelsSuccess(state, action) {
-      state.channelList = action.payload.channelList;
-    },
-    loadChannelsFailure(state, action) {
-      // todo 에러처리
-    },
     loadMyChannelsRequest(state, action: PayloadAction<{ userId: number }>) {},
     loadMyChannelsSuccess(state, action: PayloadAction<{ myChannelList: Channel[] }>) {
       state.myChannelList = action.payload.myChannelList;
@@ -66,7 +57,6 @@ const channelSlice = createSlice({
     createChannelRequest(state, action: PayloadAction<{ channelInfo: ChannelInfo; user: User }>) {},
     createChannelSuccess(state, action: PayloadAction<{ channel: Channel }>) {
       const { channel } = action.payload;
-      state.channelList.push(channel);
       state.myChannelList.push(channel);
     },
     createChannelFailure(state, action: PayloadAction<{ err: Error }>) {
@@ -150,9 +140,6 @@ const channelSlice = createSlice({
 export const CHANNEL = channelSlice.name;
 export const {
   resetChannelState,
-  loadChannelsRequest,
-  loadChannelsSuccess,
-  loadChannelsFailure,
   loadMyChannelsRequest,
   loadMyChannelsSuccess,
   loadMyChannelsFailure,

--- a/client/src/store/sagas/channelSaga.ts
+++ b/client/src/store/sagas/channelSaga.ts
@@ -3,9 +3,6 @@ import { channelService } from '@/services';
 import { Channel, ChannelInfo, JoinedUser, User } from '@/types';
 import { PayloadAction } from '@reduxjs/toolkit';
 import {
-  loadChannelsRequest,
-  loadChannelsSuccess,
-  loadChannelsFailure,
   loadMyChannelsRequest,
   loadMyChannelsSuccess,
   loadMyChannelsFailure,
@@ -22,17 +19,6 @@ import {
 } from '@/store/modules/channel.slice';
 import { setRedirect } from '@/store/modules/redirect.slice';
 import { setLastChannel } from '@/store/modules/user.slice';
-
-function* loadChannels() {
-  try {
-    const { data, status } = yield call(channelService.getChannels);
-    if (status === 200) {
-      yield put(loadChannelsSuccess({ channelList: data.channelList }));
-    }
-  } catch (err) {
-    yield put(loadChannelsFailure(err));
-  }
-}
 
 function* loadMyChannels(action: PayloadAction<{ userId: number }>) {
   const { userId } = action.payload;
@@ -129,10 +115,6 @@ function* joinChannel({ payload: { users, channelId } }: PayloadAction<joinChann
   }
 }
 
-function* watchLoadChannels() {
-  yield takeEvery(loadChannelsRequest, loadChannels);
-}
-
 function* watchLoadMyChannels() {
   yield takeEvery(loadMyChannelsRequest, loadMyChannels);
 }
@@ -151,7 +133,6 @@ function* watchJoinChannel() {
 
 export default function* channelSaga() {
   yield all([
-    fork(watchLoadChannels),
     fork(watchLoadMyChannels),
     fork(watchCreateChannel),
     fork(watchLoadChannel),


### PR DESCRIPTION
채널 스토어에서 channelList라고 있었던 상태를 아무 곳에서도 사용하지 않아 삭제하였습니다.