### PR TITLE
인피니티 스크롤 버그 수정

### DIFF
--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -51,7 +51,7 @@ const ThreadList = () => {
   const { userInfo } = useUserState();
   const {
     threadList,
-    canScroll,
+    canScrollToBottom,
     loading,
     nextThreadId,
     firstScrollUsed,
@@ -79,13 +79,13 @@ const ThreadList = () => {
     if (threadList) {
       if (
         threadList.length &&
-        canScroll &&
+        canScrollToBottom &&
         threadList[threadList.length - 1].userId === userInfo?.id
       ) {
         bottomRef.current?.scrollIntoView();
-        dispatch(setScrollable({ canScroll: false }));
+        dispatch(setScrollable({ canScrollToBottom: false }));
       }
-      if (prevTopThreadId && !canScroll) {
+      if (prevTopThreadId && !canScrollToBottom) {
         const prevTopElement = document.getElementById(`thread-${prevTopThreadId}`);
         prevTopElement?.scrollIntoView();
       }

--- a/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
+++ b/client/src/components/ThreadListBox/ThreadList/ThreadList.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import {
   addThreadListRequest,
   setFirstScrollUsed,
+  setGotoPreviousTopItemPosition,
   setScrollable,
 } from '@/store/modules/thread.slice';
 import { Thread } from '@/types';
@@ -56,6 +57,7 @@ const ThreadList = () => {
     nextThreadId,
     firstScrollUsed,
     prevTopThreadId,
+    gotoPreviousTopItemPosition,
   } = useThreadState();
 
   const onIntersect = ([{ isIntersecting }]: IntersectionObserverEntry[]) => {
@@ -85,9 +87,10 @@ const ThreadList = () => {
         bottomRef.current?.scrollIntoView();
         dispatch(setScrollable({ canScrollToBottom: false }));
       }
-      if (prevTopThreadId && !canScrollToBottom) {
+      if (gotoPreviousTopItemPosition && prevTopThreadId && !canScrollToBottom) {
         const prevTopElement = document.getElementById(`thread-${prevTopThreadId}`);
         prevTopElement?.scrollIntoView();
+        dispatch(setGotoPreviousTopItemPosition({ gotoPreviousTopItemPosition: false }));
       }
     }
   }, [threadList?.length]);

--- a/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
+++ b/client/src/components/common/ThreadInputBox/ThreadInputBox.tsx
@@ -143,7 +143,7 @@ const ThreadInputBox: React.FC<ThreadInputBoxProps> = ({ inputBoxType }: ThreadI
         }),
       );
       if (!parentId) {
-        dispatch(setScrollable({ canScroll: true }));
+        dispatch(setScrollable({ canScrollToBottom: true }));
       }
     }
   };

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -10,6 +10,7 @@ interface ThreadState {
   nextThreadId: number | null;
   firstScrollUsed: boolean;
   prevTopThreadId: number | null;
+  gotoPreviousTopItemPosition: boolean;
 }
 
 const threadListState: ThreadState = {
@@ -19,6 +20,7 @@ const threadListState: ThreadState = {
   nextThreadId: null,
   firstScrollUsed: false,
   prevTopThreadId: null,
+  gotoPreviousTopItemPosition: false,
 };
 
 export interface addThreadRequestPayload {
@@ -80,6 +82,7 @@ const threadSlice = createSlice({
         state.threadList = threadList.concat(state.threadList);
       }
       state.nextThreadId = nextThreadId;
+      state.gotoPreviousTopItemPosition = true;
     },
     addThreadListFailure(state) {
       state.loading = false;
@@ -171,6 +174,12 @@ const threadSlice = createSlice({
         });
       }
     },
+    setGotoPreviousTopItemPosition(
+      state,
+      { payload }: PayloadAction<{ gotoPreviousTopItemPosition: boolean }>,
+    ) {
+      state.gotoPreviousTopItemPosition = payload.gotoPreviousTopItemPosition;
+    },
   },
 });
 
@@ -195,6 +204,7 @@ export const {
   addThreadListSuccess,
   addThreadListFailure,
   replaceThreadsAfterUpdateUserProfile,
-} = threadSlice.actions; // action 나눠서 export 하기
+  setGotoPreviousTopItemPosition,
+} = threadSlice.actions;
 
 export default threadSlice.reducer;

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -55,6 +55,7 @@ const threadSlice = createSlice({
       state.loading = true;
       state.nextThreadId = null;
       state.firstScrollUsed = false;
+      state.threadList = null;
     },
     getThreadSuccess(state, action: PayloadAction<getThreadSuccessPayload>) {
       const { threadList, nextThreadId } = action.payload;

--- a/client/src/store/modules/thread.slice.ts
+++ b/client/src/store/modules/thread.slice.ts
@@ -5,7 +5,7 @@ import { EmojiOfThread, JoinedUser, Thread, ThreadResponse } from '@/types';
 
 interface ThreadState {
   threadList: Thread[] | null;
-  canScroll: boolean;
+  canScrollToBottom: boolean;
   loading: boolean;
   nextThreadId: number | null;
   firstScrollUsed: boolean;
@@ -14,7 +14,7 @@ interface ThreadState {
 
 const threadListState: ThreadState = {
   threadList: null,
-  canScroll: false,
+  canScrollToBottom: false,
   loading: false,
   nextThreadId: null,
   firstScrollUsed: false,
@@ -31,7 +31,7 @@ export interface getThreadRequestPayload {
 }
 export interface getThreadSuccessPayload {
   threadList: Thread[];
-  canScroll: boolean;
+  canScrollToBottom: boolean;
   nextThreadId: number | null;
 }
 
@@ -51,6 +51,7 @@ const threadSlice = createSlice({
       return threadListState;
     },
     getThreadRequest(state, action: PayloadAction<getThreadRequestPayload>) {
+      state.prevTopThreadId = null;
       state.loading = true;
       state.nextThreadId = null;
       state.firstScrollUsed = false;
@@ -85,11 +86,12 @@ const threadSlice = createSlice({
     createThreadRequest(state, action: PayloadAction<createThreadRequestPayload>) {},
     createThreadSuccess(state, action: PayloadAction<ThreadResponse>) {},
     createThreadFailure(state, action) {},
-    addThread(state, action) {
+    addThread(state, { payload }: PayloadAction<{ thread: Thread }>) {
+      const { thread } = payload;
       if (state.threadList?.length) {
-        state.threadList.push(action.payload.thread);
+        state.threadList.push(thread);
       } else {
-        state.threadList = [action.payload.thread];
+        state.threadList = [thread];
       }
     },
     deleteThread(state, { payload }: PayloadAction<{ threadId: number }>) {
@@ -130,8 +132,8 @@ const threadSlice = createSlice({
         state.threadList[targetIdx] = thread;
       }
     },
-    setScrollable(state, { payload }: PayloadAction<{ canScroll: boolean }>) {
-      state.canScroll = payload.canScroll;
+    setScrollable(state, { payload }: PayloadAction<{ canScrollToBottom: boolean }>) {
+      state.canScrollToBottom = payload.canScrollToBottom;
     },
     setFirstScrollUsed(state, { payload }: PayloadAction<{ firstScrollUsed: boolean }>) {
       state.firstScrollUsed = payload.firstScrollUsed;

--- a/client/src/store/sagas/socketSaga.ts
+++ b/client/src/store/sagas/socketSaga.ts
@@ -92,7 +92,18 @@ function subscribeSocket(socket: Socket) {
             }
             return;
           }
-          emit(addThread({ thread }));
+          if (thread.id && thread.emoji && thread.createdAt) {
+            emit(
+              addThread({
+                thread: {
+                  ...thread,
+                  id: thread.id,
+                  createdAt: thread.createdAt,
+                  emoji: thread.emoji,
+                },
+              }),
+            );
+          }
           return;
         }
         if (subType === THREAD_SUBTYPE.DELETE_THREAD) {

--- a/client/src/store/sagas/threadSaga.ts
+++ b/client/src/store/sagas/threadSaga.ts
@@ -22,7 +22,7 @@ function* getThreadList({ payload }: PayloadAction<getThreadRequestPayload>) {
     const { data, status } = yield call(threadService.getThreadList, { channelId });
     const { threadList, nextThreadId } = data;
     if (status === 200) {
-      yield put(getThreadSuccess({ threadList, canScroll: true, nextThreadId }));
+      yield put(getThreadSuccess({ threadList, canScrollToBottom: true, nextThreadId }));
     }
   } catch (err) {
     yield put(getThreadFailure(err));


### PR DESCRIPTION
## 구현 내용

## 스크롤 관련 두 가지 버그를 해결했습니다.

### 1. 인피니티 스크롤을 1번 이상 실행 후, 다른 사람한테 메시지가 오면 기존 top 위치로 이동하는 버그 해결
- 플래그 생성해서 체크하도록 변경

### 2. 다음 채널로 이동할 때, 해당 채널의 스레드 요청전 기존 threadList를 비워주도록 변경
- 이걸 안비우고 이동부터하면,  기존 스레드 리스트 때문에 스크롤 위치가 이상해지는 버그가 있어서 해결했습니다.

### 3. 명시적이지 않ㅇ은 변수명 변경
-> canScroll ---> canScrollToBottom